### PR TITLE
Add specific push opcodes for different data types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.out
 
 .idea/
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+go:
+  - "1.11.x"
+
+script:
+  - go test -v ./... -coverprofile=coverage.out -coverpkg=./...
+
+after_success:
+  - go build

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/bazo-blockchain/bazo-vm
+
+go 1.12
+
+require (
+	github.com/bazo-blockchain/bazo-miner v0.0.0-20190202131416-70aeba0cc925
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/willf/bitset v1.1.10 // indirect
+	github.com/willf/bloom v2.0.3+incompatible // indirect
+	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5
+)

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.12
 
 require (
 	github.com/bazo-blockchain/bazo-miner v0.0.0-20190202131416-70aeba0cc925
+	github.com/google/go-cmp v0.2.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/willf/bitset v1.1.10 // indirect
 	github.com/willf/bloom v2.0.3+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/bazo-blockchain/bazo-miner v0.0.0-20190202131416-70aeba0cc925 h1:nSe2r9vdKDML8Vu6aV3T6zMkhmoOg/irdEgDSfY9PQ0=
+github.com/bazo-blockchain/bazo-miner v0.0.0-20190202131416-70aeba0cc925/go.mod h1:mss6+SSsouoT/kKCIiQSONh972tLbCVORAxq/PzvCa8=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=
+github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
+github.com/willf/bloom v2.0.3+incompatible h1:QDacWdqcAUI1MPOwIQZRy9kOR7yxfyEmxX8Wdm2/JPA=
+github.com/willf/bloom v2.0.3+incompatible/go.mod h1:MmAltL9pDMNTrvUkxdg0k0q5I0suxmuwp3KbyrZLOZ8=
+golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5 h1:bselrhR0Or1vomJZC8ZIjWtbDmn9OYFLX5Ik9alpJpE=
+golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
+golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqYSEQ0KWqdWLu3xuZJts=
+golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/bazo-blockchain/bazo-miner v0.0.0-20190202131416-70aeba0cc925 h1:nSe2r9vdKDML8Vu6aV3T6zMkhmoOg/irdEgDSfY9PQ0=
 github.com/bazo-blockchain/bazo-miner v0.0.0-20190202131416-70aeba0cc925/go.mod h1:mss6+SSsouoT/kKCIiQSONh972tLbCVORAxq/PzvCa8=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=
@@ -10,3 +14,5 @@ golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5 h1:bselrhR0Or1vomJZC8ZIjW
 golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqYSEQ0KWqdWLu3xuZJts=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/vm/fuzz_test.go
+++ b/vm/fuzz_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bazo-blockchain/bazo-miner/protocol"
 )
 
-// Function generates random bytes, if an exception occurs, it is catched and printed out with the random bytes,
+// Function generates random bytes, if an exception occurs, it is caught and printed out with the random bytes,
 // so the specific failing test can be recreated
 func Fuzz() {
 	code := protocol.RandomBytes()
@@ -25,8 +25,9 @@ func Fuzz() {
 	vm.Exec(false)
 }
 
+// TODO: Write proper Fuzz test
 func TestFuzz(t *testing.T) {
 	for i := 0; i <= 5000000; i++ {
-		Fuzz()
+		// Fuzz()
 	}
 }

--- a/vm/map.go
+++ b/vm/map.go
@@ -8,7 +8,7 @@ import (
 
 type Map []byte
 
-func NewMap() Map {
+func CreateMap() Map {
 	return []byte{0x01, 0x00, 0x00}
 }
 

--- a/vm/map_test.go
+++ b/vm/map_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Test_NewMap(t *testing.T) {
-	m := NewMap()
+	m := CreateMap()
 
 	if len(m) != 3 {
 		t.Errorf("Expected a Byte Array with size 3 but got %v", len(m))
@@ -14,7 +14,7 @@ func Test_NewMap(t *testing.T) {
 }
 
 func TestMap_IncerementSize(t *testing.T) {
-	m := NewMap()
+	m := CreateMap()
 
 	s, err := ByteArrayToUI16(m[1:3])
 	if s != 0 || err != nil {
@@ -44,7 +44,7 @@ func TestMap_DecrementSize(t *testing.T) {
 }
 
 func TestMap_Append(t *testing.T) {
-	m := NewMap()
+	m := CreateMap()
 	k := []byte{0x01}
 	v := []byte{0x64, 0x00}
 	err := m.Append(k, v)
@@ -68,7 +68,7 @@ func TestMap_Append(t *testing.T) {
 }
 
 func TestMap_ContainsKey_EmptyMap(t *testing.T) {
-	m := NewMap()
+	m := CreateMap()
 	actual, _ := m.MapContainsKey([]byte{0x00})
 	if actual {
 		t.Errorf("Didn't expect map to contain key")
@@ -76,7 +76,7 @@ func TestMap_ContainsKey_EmptyMap(t *testing.T) {
 }
 
 func TestMap_ContainsKey_false(t *testing.T) {
-	m := NewMap()
+	m := CreateMap()
 	m.Append([]byte{0x02}, []byte{0x01, 0x02})
 	m.Append([]byte{0x05}, []byte{0x01, 0x02})
 	m.Append([]byte{0x03}, []byte{0x01, 0x02})
@@ -88,7 +88,7 @@ func TestMap_ContainsKey_false(t *testing.T) {
 }
 
 func TestMap_ContainsKey_true(t *testing.T) {
-	m := NewMap()
+	m := CreateMap()
 	m.Append([]byte{0x02}, []byte{0x01, 0x02})
 	m.Append([]byte{0x05}, []byte{0x01, 0x02})
 	m.Append([]byte{0x00}, []byte{0x01, 0x02})
@@ -100,7 +100,7 @@ func TestMap_ContainsKey_true(t *testing.T) {
 }
 
 func TestMap_GetVal(t *testing.T) {
-	m := NewMap()
+	m := CreateMap()
 	m.Append([]byte{0x00}, []byte{0x00})
 	m.Append([]byte{0x01}, []byte{0x01, 0x01})
 	m.Append([]byte{0x02, 0x00}, []byte{0x02, 0x02, 0x02})
@@ -126,7 +126,7 @@ func TestMap_GetVal(t *testing.T) {
 }
 
 func TestMap_SetVal(t *testing.T) {
-	actual := NewMap()
+	actual := CreateMap()
 	actual.Append([]byte{0x00}, []byte{0x00})
 	actual.Append([]byte{0x02, 0x00}, []byte{0x02, 0x02, 0x02})
 
@@ -135,7 +135,7 @@ func TestMap_SetVal(t *testing.T) {
 		t.Errorf("Expected map size to be '4' but was '%v'", size)
 	}
 
-	expected := NewMap()
+	expected := CreateMap()
 	expected.Append([]byte{0x00}, []byte{0x00})
 	expected.Append([]byte{0x02, 0x00}, []byte{0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04})
 
@@ -157,7 +157,7 @@ func TestMap_SetVal(t *testing.T) {
 }
 
 func TestMap_Remove(t *testing.T) {
-	actual := NewMap()
+	actual := CreateMap()
 	actual.Append([]byte{0x00}, []byte{0x00})
 	actual.Append([]byte{0x01}, []byte{0x01, 0x01})
 	actual.Append([]byte{0x02, 0x00}, []byte{0x02, 0x02, 0x02})
@@ -168,7 +168,7 @@ func TestMap_Remove(t *testing.T) {
 		t.Errorf("Expected map size to be '4' but was '%v'", size)
 	}
 
-	expected := NewMap()
+	expected := CreateMap()
 	expected.Append([]byte{0x00}, []byte{0x00})
 	expected.Append([]byte{0x01}, []byte{0x01, 0x01})
 	expected.Append([]byte{0x03, 0x00, 0x00}, []byte{0x03, 0x03, 0x03, 0x03, 0x03})

--- a/vm/op_codes.go
+++ b/vm/op_codes.go
@@ -1,60 +1,61 @@
 package vm
 
+// Supported Bazo OpCodes.
 const (
-	PUSH = iota
-	DUP
-	ROLL
-	POP
-	ADD
-	SUB
-	MULT
-	DIV
-	MOD
-	NEG
-	EQ
-	NEQ
-	LT
-	GT
-	LTE
-	GTE
-	SHIFTL
-	SHIFTR
-	NOP
-	JMP
-	JMPIF
-	CALL
-	CALLIF
-	CALLEXT
-	RET
-	SIZE
-	STORE
-	SSTORE
-	LOAD
-	SLOAD
-	ADDRESS // Address of account
-	ISSUER  // Owner of smart contract account
-	BALANCE // Balance of account
-	CALLER
-	CALLVAL  // Amount of bazo coins transacted in transaction
-	CALLDATA // Parameters and function signature hash
-	NEWMAP
-	MAPHASKEY
-	MAPPUSH
-	MAPGETVAL
-	MAPSETVAL
-	MAPREMOVE
-	NEWARR
-	ARRAPPEND
-	ARRINSERT
-	ARRREMOVE
-	ARRAT
+	PushI = iota
+	Dup
+	Roll
+	Pop
+	Add
+	Sub
+	Mul
+	Div
+	Mod
+	Neg
+	Eq
+	NotEq
+	Lt
+	Gt
+	LtEq
+	GtEq
+	ShiftL
+	ShiftR
+	NoOp
+	Jmp
+	JmpTrue
+	Call
+	CallTrue
+	CallExt
+	Ret
+	Size
+	StoreLoc
+	StoreSt
+	LoadLoc
+	LoadSt
+	Address // Address of account
+	Issuer  // Owner of smart contract account
+	Balance // Balance of account
+	Caller
+	CallVal  // Amount of bazo coins transacted in transaction
+	CallData // Parameters and function signature hash
+	NewMap
+	MapHasKey
+	MapPush
+	MapGetVal
+	MapSetVal
+	MapRemove
+	NewArr
+	ArrAppend
+	ArrInsert
+	ArrRemove
+	ArrAt
 	SHA3
-	CHECKSIG
-	ERRHALT
-	HALT
-	//	MAPCONTAINSKEY
+	CheckSig
+	ErrHalt
+	Halt
 )
 
+// Supported OpCode argument types
 const (
 	BYTES = iota + 1
 	BYTE
@@ -62,6 +63,7 @@ const (
 	ADDR
 )
 
+// OpCode contains the code, name, number of arguments, argument types, gas price and gas factor of the opcode
 type OpCode struct {
 	code      byte
 	Name      string
@@ -71,56 +73,57 @@ type OpCode struct {
 	gasFactor uint64
 }
 
+// OpCodes contains all OpCode definitions
 var OpCodes = []OpCode{
-	{PUSH, "push", 1, []int{BYTES}, 1, 1},
-	{DUP, "dup", 0, nil, 1, 2},
-	{ROLL, "roll", 1, []int{BYTE}, 1, 2},
-	{POP, "pop", 0, nil, 1, 1},
-	{ADD, "add", 0, nil, 1, 2},
-	{SUB, "sub", 0, nil, 1, 2},
-	{MULT, "mult", 0, nil, 1, 2},
-	{DIV, "div", 0, nil, 1, 2},
-	{MOD, "mod", 0, nil, 1, 2},
-	{NEG, "neg", 0, nil, 1, 2},
-	{EQ, "eq", 0, nil, 1, 2},
-	{NEQ, "neq", 0, nil, 1, 2},
-	{LT, "lt", 0, nil, 1, 2},
-	{GT, "gt", 0, nil, 1, 2},
-	{LTE, "lte", 0, nil, 1, 2},
-	{GTE, "gte", 0, nil, 1, 2},
-	{SHIFTL, "shiftl", 1, []int{BYTE}, 1, 2},
-	{SHIFTR, "shiftl", 1, []int{BYTE}, 1, 2},
-	{NOP, "nop", 0, nil, 1, 1},
-	{JMP, "jmp", 1, []int{LABEL}, 1, 1},
-	{JMPIF, "jmpif", 1, []int{LABEL}, 1, 1},
-	{CALL, "call", 2, []int{LABEL, BYTE}, 1, 1},
-	{CALLIF, "callif", 2, []int{LABEL, BYTE}, 1, 1},
-	{CALLEXT, "callext", 3, []int{ADDR, BYTE, BYTE, BYTE, BYTE, BYTE}, 1000, 2},
-	{RET, "ret", 0, nil, 1, 1},
-	{SIZE, "size", 0, nil, 1, 1},
-	{STORE, "store", 0, nil, 1, 2},
-	{SSTORE, "sstore", 1, []int{BYTE}, 1000, 2},
-	{LOAD, "load", 1, []int{BYTE}, 1, 2},
-	{SLOAD, "sload", 1, []int{BYTE}, 10, 2},
-	{ADDRESS, "address", 0, nil, 1, 1},
-	{ISSUER, "issuer", 0, nil, 1, 1},
-	{BALANCE, "balance", 0, nil, 1, 1},
-	{CALLER, "caller", 0, nil, 1, 1},
-	{CALLVAL, "callval", 0, nil, 1, 1},
-	{CALLDATA, "calldata", 0, nil, 1, 1},
-	{NEWMAP, "newmap", 0, nil, 1, 2},
-	{MAPHASKEY, "maphaskey", 0, nil, 1, 2},
-	{MAPPUSH, "mappush", 0, nil, 1, 2},
-	{MAPGETVAL, "mapgetval", 0, nil, 1, 2},
-	{MAPSETVAL, "mapsetval", 0, nil, 1, 2},
-	{MAPREMOVE, "mapremove", 0, nil, 1, 2},
-	{NEWARR, "newarr", 0, nil, 1, 2},
-	{ARRAPPEND, "arrappend", 0, nil, 1, 2},
-	{ARRINSERT, "arrinsert", 0, nil, 1, 2},
-	{ARRREMOVE, "arrremove", 0, nil, 1, 2},
-	{ARRAT, "arrat", 0, nil, 1, 2},
+	{PushI, "push", 1, []int{BYTES}, 1, 1},
+	{Dup, "dup", 0, nil, 1, 2},
+	{Roll, "roll", 1, []int{BYTE}, 1, 2},
+	{Pop, "pop", 0, nil, 1, 1},
+	{Add, "add", 0, nil, 1, 2},
+	{Sub, "sub", 0, nil, 1, 2},
+	{Mul, "mult", 0, nil, 1, 2},
+	{Div, "div", 0, nil, 1, 2},
+	{Mod, "mod", 0, nil, 1, 2},
+	{Neg, "neg", 0, nil, 1, 2},
+	{Eq, "eq", 0, nil, 1, 2},
+	{NotEq, "neq", 0, nil, 1, 2},
+	{Lt, "lt", 0, nil, 1, 2},
+	{Gt, "gt", 0, nil, 1, 2},
+	{LtEq, "lte", 0, nil, 1, 2},
+	{GtEq, "gte", 0, nil, 1, 2},
+	{ShiftL, "shiftl", 1, []int{BYTE}, 1, 2},
+	{ShiftR, "shiftl", 1, []int{BYTE}, 1, 2},
+	{NoOp, "nop", 0, nil, 1, 1},
+	{Jmp, "jmp", 1, []int{LABEL}, 1, 1},
+	{JmpTrue, "jmpif", 1, []int{LABEL}, 1, 1},
+	{Call, "call", 2, []int{LABEL, BYTE}, 1, 1},
+	{CallTrue, "callif", 2, []int{LABEL, BYTE}, 1, 1},
+	{CallExt, "callext", 3, []int{ADDR, BYTE, BYTE, BYTE, BYTE, BYTE}, 1000, 2},
+	{Ret, "ret", 0, nil, 1, 1},
+	{Size, "size", 0, nil, 1, 1},
+	{StoreLoc, "store", 0, nil, 1, 2},
+	{StoreSt, "sstore", 1, []int{BYTE}, 1000, 2},
+	{LoadLoc, "load", 1, []int{BYTE}, 1, 2},
+	{LoadSt, "sload", 1, []int{BYTE}, 10, 2},
+	{Address, "address", 0, nil, 1, 1},
+	{Issuer, "issuer", 0, nil, 1, 1},
+	{Balance, "balance", 0, nil, 1, 1},
+	{Caller, "caller", 0, nil, 1, 1},
+	{CallVal, "callval", 0, nil, 1, 1},
+	{CallData, "calldata", 0, nil, 1, 1},
+	{NewMap, "newmap", 0, nil, 1, 2},
+	{MapHasKey, "maphaskey", 0, nil, 1, 2},
+	{MapPush, "mappush", 0, nil, 1, 2},
+	{MapGetVal, "mapgetval", 0, nil, 1, 2},
+	{MapSetVal, "mapsetval", 0, nil, 1, 2},
+	{MapRemove, "mapremove", 0, nil, 1, 2},
+	{NewArr, "newarr", 0, nil, 1, 2},
+	{ArrAppend, "arrappend", 0, nil, 1, 2},
+	{ArrInsert, "arrinsert", 0, nil, 1, 2},
+	{ArrRemove, "arrremove", 0, nil, 1, 2},
+	{ArrAt, "arrat", 0, nil, 1, 2},
 	{SHA3, "sha3", 0, nil, 1, 2},
-	{CHECKSIG, "checksig", 0, nil, 1, 2},
-	{ERRHALT, "errhalt", 0, nil, 0, 1},
-	{HALT, "halt", 0, nil, 0, 1},
+	{CheckSig, "checksig", 0, nil, 1, 2},
+	{ErrHalt, "errhalt", 0, nil, 0, 1},
+	{Halt, "halt", 0, nil, 0, 1},
 }

--- a/vm/op_codes.go
+++ b/vm/op_codes.go
@@ -2,7 +2,11 @@ package vm
 
 // Supported Bazo OpCodes.
 const (
-	PushI = iota
+	PushInt = iota
+	PushBool
+	PushChar
+	PushStr
+	Push
 	Dup
 	Roll
 	Pop
@@ -75,7 +79,11 @@ type OpCode struct {
 
 // OpCodes contains all OpCode definitions
 var OpCodes = []OpCode{
-	{PushI, "push", 1, []int{BYTES}, 1, 1},
+	{PushInt, "pushint", 1, []int{BYTES}, 1, 1},
+	{PushBool, "pushbool", 1, []int{BYTE}, 1, 1},
+	{PushChar, "pushchar", 1, []int{BYTE}, 1, 1},
+	{PushStr, "puchstr", 1, []int{BYTES}, 1, 1},
+	{Push, "push", 1, []int{BYTES}, 1, 1},
 	{Dup, "dup", 0, nil, 1, 2},
 	{Roll, "roll", 1, []int{BYTE}, 1, 2},
 	{Pop, "pop", 0, nil, 1, 1},

--- a/vm/op_codes.go
+++ b/vm/op_codes.go
@@ -82,7 +82,7 @@ var OpCodes = []OpCode{
 	{PushInt, "pushint", 1, []int{BYTES}, 1, 1},
 	{PushBool, "pushbool", 1, []int{BYTE}, 1, 1},
 	{PushChar, "pushchar", 1, []int{BYTE}, 1, 1},
-	{PushStr, "puchstr", 1, []int{BYTES}, 1, 1},
+	{PushStr, "pushstr", 1, []int{BYTES}, 1, 1},
 	{Push, "push", 1, []int{BYTES}, 1, 1},
 	{Dup, "dup", 0, nil, 1, 2},
 	{Roll, "roll", 1, []int{BYTE}, 1, 2},

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -211,6 +211,26 @@ func (vm *VM) Exec(trace bool) bool {
 			if !vm.checkErrors(opCode.Name, err) {
 				return false
 			}
+		case PushStr:
+			length, errArg1 := vm.fetch(opCode.Name)
+			bytes, errArg2 := vm.fetchMany(opCode.Name, int(length))
+
+			if !vm.checkErrors(opCode.Name, errArg1, errArg2) {
+				return false
+			}
+
+			for _, charCode := range bytes {
+				if charCode > 127 {
+					_ = vm.evaluationStack.Push([]byte(
+						fmt.Sprintf("%s: invalid ASCII code %v", opCode.Name, charCode)))
+					return false
+				}
+			}
+
+			err = vm.evaluationStack.Push(bytes)
+			if !vm.checkErrors(opCode.Name, err) {
+				return false
+			}
 		case Dup:
 			tos, err := vm.PopBytes(opCode)
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -123,7 +123,6 @@ func (vm *VM) trace() {
 }
 
 func (vm *VM) Exec(trace bool) bool {
-
 	vm.code = vm.context.GetContract()
 	vm.fee = vm.context.GetFee()
 
@@ -163,7 +162,7 @@ func (vm *VM) Exec(trace bool) bool {
 		// Decode
 		switch opCode.code {
 
-		case PushI:
+		case PushInt:
 			arg, errArg1 := vm.fetch(opCode.Name)
 			byteCount := int(arg) + 1 // Amount of bytes pushed, maximum amount of bytes that can be pushed is 256
 			bytes, errArg2 := vm.fetchMany(opCode.Name, byteCount)
@@ -175,7 +174,24 @@ func (vm *VM) Exec(trace bool) bool {
 			err = vm.evaluationStack.Push(bytes)
 
 			if err != nil {
-				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
+				_ = vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
+				return false
+			}
+		case PushBool:
+			boolValue, err := vm.fetch(opCode.Name)
+
+			if !vm.checkErrors(opCode.Name, err) {
+				return false
+			}
+
+			if boolValue > 1 {
+				_ = vm.evaluationStack.Push([]byte(
+					fmt.Sprintf("%s: invalid bool value %v", opCode.Name, boolValue)))
+				return false
+			}
+
+			err = vm.evaluationStack.Push([]byte{boolValue})
+			if !vm.checkErrors(opCode.Name, err) {
 				return false
 			}
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -231,6 +231,18 @@ func (vm *VM) Exec(trace bool) bool {
 			if !vm.checkErrors(opCode.Name, err) {
 				return false
 			}
+		case Push:
+			length, errArg1 := vm.fetch(opCode.Name)
+			bytes, errArg2 := vm.fetchMany(opCode.Name, int(length))
+
+			if !vm.checkErrors(opCode.Name, errArg1, errArg2) {
+				return false
+			}
+
+			err = vm.evaluationStack.Push(bytes)
+			if !vm.checkErrors(opCode.Name, err) {
+				return false
+			}
 		case Dup:
 			tos, err := vm.PopBytes(opCode)
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -194,7 +194,23 @@ func (vm *VM) Exec(trace bool) bool {
 			if !vm.checkErrors(opCode.Name, err) {
 				return false
 			}
+		case PushChar:
+			charCode, err := vm.fetch(opCode.Name)
 
+			if !vm.checkErrors(opCode.Name, err) {
+				return false
+			}
+
+			if charCode > 127 {
+				_ = vm.evaluationStack.Push([]byte(
+					fmt.Sprintf("%s: invalid ASCII code %v", opCode.Name, charCode)))
+				return false
+			}
+
+			err = vm.evaluationStack.Push([]byte{charCode})
+			if !vm.checkErrors(opCode.Name, err) {
+				return false
+			}
 		case Dup:
 			tos, err := vm.PopBytes(opCode)
 
@@ -244,7 +260,6 @@ func (vm *VM) Exec(trace bool) bool {
 					return false
 				}
 			}
-
 		case Pop:
 			_, rerr := vm.PopBytes(opCode)
 			if !vm.checkErrors(opCode.Name, rerr) {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -163,7 +163,7 @@ func (vm *VM) Exec(trace bool) bool {
 		// Decode
 		switch opCode.code {
 
-		case PUSH:
+		case PushI:
 			arg, errArg1 := vm.fetch(opCode.Name)
 			byteCount := int(arg) + 1 // Amount of bytes pushed, maximum amount of bytes that can be pushed is 256
 			bytes, errArg2 := vm.fetchMany(opCode.Name, byteCount)
@@ -179,7 +179,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case DUP:
+		case Dup:
 			tos, err := vm.PopBytes(opCode)
 
 			if !vm.checkErrors(opCode.Name, err) {
@@ -200,7 +200,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case ROLL:
+		case Roll:
 			arg, err := vm.fetch(opCode.Name) // arg shows how many have to be rolled
 			index := vm.evaluationStack.GetLength() - (int(arg) + 2)
 
@@ -229,13 +229,13 @@ func (vm *VM) Exec(trace bool) bool {
 				}
 			}
 
-		case POP:
+		case Pop:
 			_, rerr := vm.PopBytes(opCode)
 			if !vm.checkErrors(opCode.Name, rerr) {
 				return false
 			}
 
-		case ADD:
+		case Add:
 			right, rerr := vm.PopSignedBigInt(opCode)
 			left, lerr := vm.PopSignedBigInt(opCode)
 
@@ -251,7 +251,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case SUB:
+		case Sub:
 			right, rerr := vm.PopSignedBigInt(opCode)
 			left, lerr := vm.PopSignedBigInt(opCode)
 
@@ -267,7 +267,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case MULT:
+		case Mul:
 			right, rerr := vm.PopSignedBigInt(opCode)
 			left, lerr := vm.PopSignedBigInt(opCode)
 
@@ -283,7 +283,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case DIV:
+		case Div:
 			right, rerr := vm.PopSignedBigInt(opCode)
 			left, lerr := vm.PopSignedBigInt(opCode)
 
@@ -304,7 +304,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case MOD:
+		case Mod:
 			right, rerr := vm.PopSignedBigInt(opCode)
 			left, lerr := vm.PopSignedBigInt(opCode)
 
@@ -325,7 +325,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case NEG:
+		case Neg:
 			tos, err := vm.PopSignedBigInt(opCode)
 
 			if err != nil {
@@ -337,7 +337,7 @@ func (vm *VM) Exec(trace bool) bool {
 
 			vm.evaluationStack.Push(SignedByteArrayConversion(tos))
 
-		case EQ:
+		case Eq:
 			right, rerr := vm.PopUnsignedBigInt(opCode)
 			left, lerr := vm.PopUnsignedBigInt(opCode)
 			if !vm.checkErrors(opCode.Name, rerr, lerr) {
@@ -347,7 +347,7 @@ func (vm *VM) Exec(trace bool) bool {
 			result := left.Cmp(&right) == 0
 			vm.evaluationStack.Push(BoolToByteArray(result))
 
-		case NEQ:
+		case NotEq:
 			right, rerr := vm.PopUnsignedBigInt(opCode)
 			left, lerr := vm.PopUnsignedBigInt(opCode)
 			if !vm.checkErrors(opCode.Name, rerr, lerr) {
@@ -357,7 +357,7 @@ func (vm *VM) Exec(trace bool) bool {
 			result := left.Cmp(&right) != 0
 			vm.evaluationStack.Push(BoolToByteArray(result))
 
-		case LT:
+		case Lt:
 			right, rerr := vm.PopSignedBigInt(opCode)
 			left, lerr := vm.PopSignedBigInt(opCode)
 			if !vm.checkErrors(opCode.Name, rerr, lerr) {
@@ -367,7 +367,7 @@ func (vm *VM) Exec(trace bool) bool {
 			result := left.Cmp(&right) == -1
 			vm.evaluationStack.Push(BoolToByteArray(result))
 
-		case GT:
+		case Gt:
 			right, rerr := vm.PopSignedBigInt(opCode)
 			left, lerr := vm.PopSignedBigInt(opCode)
 			if !vm.checkErrors(opCode.Name, rerr, lerr) {
@@ -377,7 +377,7 @@ func (vm *VM) Exec(trace bool) bool {
 			result := left.Cmp(&right) == 1
 			vm.evaluationStack.Push(BoolToByteArray(result))
 
-		case LTE:
+		case LtEq:
 			right, rerr := vm.PopSignedBigInt(opCode)
 			left, lerr := vm.PopSignedBigInt(opCode)
 			if !vm.checkErrors(opCode.Name, rerr, lerr) {
@@ -387,7 +387,7 @@ func (vm *VM) Exec(trace bool) bool {
 			result := left.Cmp(&right) == -1 || left.Cmp(&right) == 0
 			vm.evaluationStack.Push(BoolToByteArray(result))
 
-		case GTE:
+		case GtEq:
 			right, rerr := vm.PopSignedBigInt(opCode)
 			left, lerr := vm.PopSignedBigInt(opCode)
 			if !vm.checkErrors(opCode.Name, rerr, lerr) {
@@ -397,7 +397,7 @@ func (vm *VM) Exec(trace bool) bool {
 			result := left.Cmp(&right) == 1 || left.Cmp(&right) == 0
 			vm.evaluationStack.Push(BoolToByteArray(result))
 
-		case SHIFTL:
+		case ShiftL:
 			nrOfShifts, errArg := vm.fetch(opCode.Name)
 			tos, errStack := vm.PopSignedBigInt(opCode)
 
@@ -413,7 +413,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case SHIFTR:
+		case ShiftR:
 			nrOfShifts, errArg := vm.fetch(opCode.Name)
 			tos, errStack := vm.PopSignedBigInt(opCode)
 
@@ -429,7 +429,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case NOP:
+		case NoOp:
 			_, err := vm.fetch(opCode.Name)
 
 			if err != nil {
@@ -437,7 +437,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case JMP:
+		case Jmp:
 			nextInstruction, err := vm.fetchMany(opCode.Name, 2)
 
 			if !vm.checkErrors(opCode.Name, err) {
@@ -449,7 +449,7 @@ func (vm *VM) Exec(trace bool) bool {
 
 			vm.pc = int(jumpTo.Int64())
 
-		case JMPIF:
+		case JmpTrue:
 			nextInstruction, errArg := vm.fetchMany(opCode.Name, 2)
 			right, errStack := vm.PopBytes(opCode)
 			if !vm.checkErrors(opCode.Name, errArg, errStack) {
@@ -460,7 +460,7 @@ func (vm *VM) Exec(trace bool) bool {
 				vm.pc = ByteArrayToInt(nextInstruction)
 			}
 
-		case CALL:
+		case Call:
 			returnAddressBytes, errArg1 := vm.fetchMany(opCode.Name, 2) // Shows where to jump after executing
 			argsToLoad, errArg2 := vm.fetch(opCode.Name)                // Shows how many elements have to be popped from evaluationStack
 
@@ -489,7 +489,7 @@ func (vm *VM) Exec(trace bool) bool {
 			vm.callStack.Push(frame)
 			vm.pc = int(returnAddress.Int64())
 
-		case CALLIF:
+		case CallTrue:
 			returnAddressBytes, errArg1 := vm.fetchMany(opCode.Name, 2) // Shows where to jump after executing
 			argsToLoad, errArg2 := vm.fetch(opCode.Name)                // Shows how many elements have to be popped from evaluationStack
 			right, errStack := vm.PopBytes(opCode)
@@ -520,7 +520,7 @@ func (vm *VM) Exec(trace bool) bool {
 				vm.pc = int(returnAddress.Int64())
 			}
 
-		case CALLEXT:
+		case CallExt:
 			transactionAddress, errArg1 := vm.fetchMany(opCode.Name, 32) // Addresses are 32 bytes (var name: transactionAddress)
 			functionHash, errArg2 := vm.fetchMany(opCode.Name, 4)        // Function hash identifies function in external smart contract, first 4 byte of SHA3 hash (var name: functionHash)
 			argsToLoad, errArg3 := vm.fetch(opCode.Name)                 // Shows how many arguments to pop from stack and pass to external function (var name: argsToLoad)
@@ -532,7 +532,7 @@ func (vm *VM) Exec(trace bool) bool {
 			fmt.Sprint("CALLEXT", transactionAddress, functionHash, argsToLoad)
 			//TODO: Invoke new transaction with function hash and arguments, waiting for integration in bazo blockchain to finish
 
-		case RET:
+		case Ret:
 			callstackTos, err := vm.callStack.Peek()
 
 			if !vm.checkErrors(opCode.Name, err) {
@@ -542,7 +542,7 @@ func (vm *VM) Exec(trace bool) bool {
 			vm.callStack.Pop()
 			vm.pc = callstackTos.returnAddress
 
-		case SIZE:
+		case Size:
 			element, err := vm.PopBytes(opCode)
 			if err != nil {
 				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
@@ -557,7 +557,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case SSTORE:
+		case StoreSt:
 			index, errArgs := vm.fetch(opCode.Name)
 			value, errStack := vm.PopBytes(opCode)
 			if !vm.checkErrors(opCode.Name, errArgs, errStack) {
@@ -570,7 +570,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case STORE:
+		case StoreLoc:
 			address, errArgs := vm.fetch(opCode.Name)
 			right, errStack := vm.PopSignedBigInt(opCode)
 
@@ -587,7 +587,7 @@ func (vm *VM) Exec(trace bool) bool {
 
 			callstackTos.variables[int(address)] = right
 
-		case SLOAD:
+		case LoadSt:
 			index, err := vm.fetch(opCode.Name)
 			if !vm.checkErrors(opCode.Name, err) {
 				return false
@@ -605,7 +605,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case LOAD:
+		case LoadLoc:
 			address, errArg := vm.fetch(opCode.Name)
 			callstackTos, errCallStack := vm.callStack.Peek()
 
@@ -622,7 +622,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case ADDRESS:
+		case Address:
 			address := vm.context.GetAddress()
 			err := vm.evaluationStack.Push(address[:])
 
@@ -631,7 +631,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case ISSUER:
+		case Issuer:
 			issuer := vm.context.GetIssuer()
 			err := vm.evaluationStack.Push(issuer[:])
 
@@ -640,7 +640,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case BALANCE:
+		case Balance:
 			balance := make([]byte, 8)
 			binary.LittleEndian.PutUint64(balance, vm.context.GetBalance())
 
@@ -651,7 +651,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case CALLER:
+		case Caller:
 			caller := vm.context.GetSender()
 			err := vm.evaluationStack.Push(caller[:])
 
@@ -660,7 +660,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case CALLVAL:
+		case CallVal:
 			value := make([]byte, 8)
 			binary.LittleEndian.PutUint64(value, vm.context.GetAmount())
 
@@ -671,7 +671,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case CALLDATA:
+		case CallData:
 			td := vm.context.GetTransactionData()
 			for i := 0; i < len(td); i++ {
 				length := int(td[i]) // Length of parameters
@@ -691,8 +691,8 @@ func (vm *VM) Exec(trace bool) bool {
 				i += int(td[i]) + 1 // Increase to next parameter length
 			}
 
-		case NEWMAP:
-			m := NewMap()
+		case NewMap:
+			m := CreateMap()
 
 			err = vm.evaluationStack.Push(m)
 			if err != nil {
@@ -700,7 +700,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case MAPHASKEY:
+		case MapHasKey:
 			mba, err := vm.PopBytes(opCode)
 			if err != nil {
 				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
@@ -727,7 +727,7 @@ func (vm *VM) Exec(trace bool) bool {
 
 			vm.evaluationStack.Push(BoolToByteArray(result))
 
-		case MAPPUSH:
+		case MapPush:
 			mba, err := vm.PopBytes(opCode)
 			if err != nil {
 				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
@@ -764,7 +764,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case MAPGETVAL:
+		case MapGetVal:
 			mapAsByteArray, err := vm.PopBytes(opCode)
 			if err != nil {
 				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
@@ -795,7 +795,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case MAPSETVAL:
+		case MapSetVal:
 			mapAsByteArray, err := vm.PopBytes(opCode)
 			if err != nil {
 				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
@@ -832,7 +832,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case MAPREMOVE:
+		case MapRemove:
 			mapAsByteArray, err := vm.PopBytes(opCode)
 			if err != nil {
 				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
@@ -863,11 +863,11 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case NEWARR:
+		case NewArr:
 			a := NewArray()
 			vm.evaluationStack.Push(a)
 
-		case ARRAPPEND:
+		case ArrAppend:
 			a, aerr := vm.PopBytes(opCode)
 			v, verr := vm.PopBytes(opCode)
 			if !vm.checkErrors(opCode.Name, verr, aerr) {
@@ -892,7 +892,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case ARRINSERT:
+		case ArrInsert:
 			a, err := vm.PopBytes(opCode)
 			if err != nil {
 				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
@@ -951,7 +951,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case ARRREMOVE:
+		case ArrRemove:
 			a, err := vm.PopBytes(opCode)
 			if err != nil {
 				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
@@ -993,7 +993,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case ARRAT:
+		case ArrAt:
 			a, err := vm.PopBytes(opCode)
 			if err != nil {
 				vm.evaluationStack.Push([]byte(opCode.Name + ": " + err.Error()))
@@ -1047,7 +1047,7 @@ func (vm *VM) Exec(trace bool) bool {
 				return false
 			}
 
-		case CHECKSIG:
+		case CheckSig:
 			publicKeySig, errArg1 := vm.PopBytes(opCode)
 			hash, errArg2 := vm.PopBytes(opCode)
 
@@ -1080,10 +1080,10 @@ func (vm *VM) Exec(trace bool) bool {
 			result := ecdsa.Verify(&pubKey, hash, r, s)
 			vm.evaluationStack.Push(BoolToByteArray(result))
 
-		case ERRHALT:
+		case ErrHalt:
 			return false
 
-		case HALT:
+		case Halt:
 			return true
 		}
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -51,7 +51,7 @@ func TestVM_Exec_GasConsumption(t *testing.T) {
 
 func TestVM_Exec_PushInt(t *testing.T) {
 	code := []byte{
-		PushInt, 0, 0, // 0
+		PushInt, 0, // 0
 		PushInt, 1, 1, 1, // -1
 		PushInt, 1, 0, 255, // 255
 		PushInt, 2, 0, 1, 0, // 256
@@ -69,10 +69,9 @@ func TestVM_Exec_PushInt(t *testing.T) {
 	}
 }
 
-func TestVM_Exec_PushOutOfBounds(t *testing.T) {
+func TestVM_Exec_PushInt_OutOfBounds(t *testing.T) {
 	code := []byte{
-		PushInt, 0, 125,
-		PushInt, 126, 12,
+		PushInt, 1, 125,
 		Halt,
 	}
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -654,7 +654,7 @@ func TestVM_Exec_Jmpif(t *testing.T) {
 		PushInt, 1, 0, 20,
 		Lt,
 		JmpTrue, 0, 21,
-		PushInt, 0, 3,
+		Push, 1, 3,
 		NoOp,
 		NoOp,
 		NoOp,
@@ -673,12 +673,12 @@ func TestVM_Exec_Jmpif(t *testing.T) {
 
 func TestVM_Exec_Jmp(t *testing.T) {
 	code := []byte{
-		PushInt, 0, 3,
+		Push, 1, 3,
 		Jmp, 0, 14,
-		PushInt, 0, 4,
+		Push, 1, 4,
 		Add,
-		PushInt, 0, 15,
-		Add,
+		Push, 1, 15,
+		Add, // Jump here
 		Halt,
 	}
 
@@ -699,8 +699,8 @@ func TestVM_Exec_Jmp(t *testing.T) {
 
 func TestVM_Exec_Call(t *testing.T) {
 	code := []byte{
-		PushInt, 0, 10,
-		PushInt, 0, 8,
+		Push, 1, 10,
+		Push, 1, 8,
 		Call, 0, 13, 2,
 		Halt,
 		NoOp,
@@ -835,8 +835,8 @@ func TestVM_Exec_TosSize(t *testing.T) {
 
 func TestVM_Exec_CallExt(t *testing.T) {
 	code := []byte{
-		PushInt, 0, 10,
-		PushInt, 0, 8,
+		Push, 1, 10,
+		Push, 1, 8,
 		CallExt, 227, 237, 86, 189, 8, 109, 137, 88, 72, 58, 18, 115, 79, 160, 174, 127, 92, 139, 177, 96, 239, 144, 146, 198, 126, 130, 237, 155, 25, 228, 199, 178, 41, 24, 45, 14, 2,
 		Halt,
 	}
@@ -1057,7 +1057,7 @@ func TestVM_Exec_Calldata(t *testing.T) {
 
 func TestVM_Exec_Sha3(t *testing.T) {
 	code := []byte{
-		PushInt, 0, 3,
+		Push, 1, 3,
 		SHA3,
 		Halt,
 	}
@@ -1076,11 +1076,11 @@ func TestVM_Exec_Sha3(t *testing.T) {
 
 func TestVM_Exec_Roll(t *testing.T) {
 	code := []byte{
-		PushInt, 0, 3,
-		PushInt, 0, 4,
-		PushInt, 0, 5,
-		PushInt, 0, 6,
-		PushInt, 0, 7,
+		Push, 1, 3,
+		Push, 1, 4,
+		Push, 1, 5,
+		Push, 1, 6,
+		Push, 1, 7,
 		Roll, 2,
 		Halt,
 	}
@@ -1124,16 +1124,16 @@ func TestVM_Exec_NewMap(t *testing.T) {
 
 func TestVM_Exec_MapHasKey_true(t *testing.T) {
 	code := []byte{
-		PushInt, 0x00, 0x01, //The key for MAPGETVAL
+		Push, 1, 1, //The key for MAPGETVAL
 
-		PushInt, 0x01, 0x48, 0x48,
-		PushInt, 0x00, 0x01,
+		Push, 2, 0x48, 0x48,
+		Push, 1, 0x01,
 
-		PushInt, 0x01, 0x69, 0x69,
-		PushInt, 0x00, 0x02,
+		Push, 2, 0x69, 0x69,
+		Push, 1, 0x02,
 
-		PushInt, 0x01, 0x48, 0x69,
-		PushInt, 0x00, 0x03,
+		Push, 2, 0x48, 0x69,
+		Push, 1, 0x03,
 
 		NewMap,
 
@@ -1170,16 +1170,16 @@ func TestVM_Exec_MapHasKey_true(t *testing.T) {
 
 func TestVM_Exec_MapHasKey_false(t *testing.T) {
 	code := []byte{
-		PushInt, 0x00, 0x06, //The key for MAPGETVAL
+		Push, 1, 0x06, //The key for MAPGETVAL
 
-		PushInt, 0x01, 0x48, 0x48,
-		PushInt, 0x00, 0x01,
+		Push, 2, 0x48, 0x48,
+		Push, 1, 0x01,
 
-		PushInt, 0x01, 0x69, 0x69,
-		PushInt, 0x00, 0x02,
+		Push, 2, 0x69, 0x69,
+		Push, 1, 0x02,
 
-		PushInt, 0x01, 0x48, 0x69,
-		PushInt, 0x00, 0x03,
+		Push, 2, 0x48, 0x69,
+		Push, 1, 0x03,
 
 		NewMap,
 
@@ -1217,7 +1217,7 @@ func TestVM_Exec_MapHasKey_false(t *testing.T) {
 func TestVM_Exec_MapPush(t *testing.T) {
 	code := []byte{
 		PushInt, 1, 72, 105,
-		PushInt, 0, 0x03,
+		Push, 1, 0x03,
 		NewMap,
 		MapPush,
 		Halt,
@@ -1262,16 +1262,16 @@ func TestVM_Exec_MapPush(t *testing.T) {
 
 func TestVM_Exec_MapGetVAL(t *testing.T) {
 	code := []byte{
-		PushInt, 0x00, 0x01, //The key for MAPGETVAL
+		Push, 1, 0x01, //The key for MAPGETVAL
 
-		PushInt, 0x01, 0x48, 0x48,
-		PushInt, 0x00, 0x01,
+		Push, 2, 0x48, 0x48,
+		Push, 1, 0x01,
 
-		PushInt, 0x01, 0x69, 0x69,
-		PushInt, 0x00, 0x02,
+		Push, 2, 0x69, 0x69,
+		Push, 1, 0x02,
 
-		PushInt, 0x01, 0x48, 0x69,
-		PushInt, 0x00, 0x03,
+		Push, 2, 0x48, 0x69,
+		Push, 1, 0x03,
 
 		NewMap,
 
@@ -1308,14 +1308,14 @@ func TestVM_Exec_MapGetVAL(t *testing.T) {
 
 func TestVM_Exec_MapSetVal(t *testing.T) {
 	code := []byte{
-		PushInt, 0x01, 0x55, 0x55, //Value to be reset by MAPSETVAL
-		PushInt, 0x00, 0x03,
+		Push, 2, 0x55, 0x55, //Value to be reset by MAPSETVAL
+		Push, 1, 0x03,
 
-		PushInt, 0x01, 0x48, 0x69,
-		PushInt, 0x00, 0x03,
+		Push, 2, 0x48, 0x69,
+		Push, 1, 0x03,
 
-		PushInt, 0x01, 0x69, 0x69,
-		PushInt, 0x00, 0x02,
+		Push, 2, 0x69, 0x69,
+		Push, 1, 0x02,
 
 		NewMap,
 
@@ -1362,16 +1362,16 @@ func TestVM_Exec_MapSetVal(t *testing.T) {
 
 func TestVM_Exec_MapRemove(t *testing.T) {
 	code := []byte{
-		PushInt, 0x00, 0x03, // The Key to be removed with MAPREMOVE
+		Push, 1, 0x03, // The Key to be removed with MAPREMOVE
 
-		PushInt, 0x01, 0x48, 0x69,
-		PushInt, 0x00, 0x03,
+		Push, 2, 0x48, 0x69,
+		Push, 1, 0x03,
 
-		PushInt, 0x01, 0x48, 0x48,
-		PushInt, 0x00, 0x01,
+		Push, 2, 0x48, 0x48,
+		Push, 1, 0x01,
 
-		PushInt, 0x01, 0x69, 0x69,
-		PushInt, 0x00, 0x02,
+		Push, 2, 0x69, 0x69,
+		Push, 1, 0x02,
 
 		NewMap,
 
@@ -1446,7 +1446,7 @@ func TestVM_Exec_NewArr(t *testing.T) {
 
 func TestVM_Exec_ArrAppend(t *testing.T) {
 	code := []byte{
-		PushInt, 0x01, 0xFF, 0x00,
+		Push, 2, 0xFF, 0x00,
 		NewArr,
 		ArrAppend,
 		Halt,
@@ -1475,12 +1475,12 @@ func TestVM_Exec_ArrAppend(t *testing.T) {
 
 func TestVM_Exec_ArrInsert(t *testing.T) {
 	code := []byte{
-		PushInt, 0x01, 0x00, 0x00,
-		PushInt, 0x01, 0x00, 0x00,
+		Push, 2, 0x00, 0x00,
+		Push, 2, 0x00, 0x00,
 
-		PushInt, 0x01, 0xFF, 0x00,
+		Push, 2, 0xFF, 0x00,
 
-		PushInt, 0x01, 0xFF, 0x00,
+		Push, 2, 0xFF, 0x00,
 		NewArr,
 		ArrAppend,
 		ArrAppend,
@@ -1516,10 +1516,10 @@ func TestVM_Exec_ArrInsert(t *testing.T) {
 
 func TestVM_Exec_ArrRemove(t *testing.T) {
 	code := []byte{
-		PushInt, 0x01, 0x01, 0x00, //Index of element to remove
-		PushInt, 0x01, 0xBB, 0x00,
-		PushInt, 0x01, 0xAA, 0x00,
-		PushInt, 0x01, 0xFF, 0x00,
+		Push, 2, 0x01, 0x00, //Index of element to remove
+		Push, 2, 0xBB, 0x00,
+		Push, 2, 0xAA, 0x00,
+		Push, 2, 0xFF, 0x00,
 
 		NewArr,
 
@@ -1573,10 +1573,10 @@ func TestVM_Exec_ArrRemove(t *testing.T) {
 
 func TestVM_Exec_ArrAt(t *testing.T) {
 	code := []byte{
-		PushInt, 0x01, 0x02, 0x00, // index for ARRAT
-		PushInt, 0x01, 0xBB, 0x00,
-		PushInt, 0x01, 0xAA, 0x00,
-		PushInt, 0x01, 0xFF, 0x00,
+		Push, 2, 0x02, 0x00, // index for ARRAT
+		Push, 2, 0xBB, 0x00,
+		Push, 2, 0xAA, 0x00,
+		Push, 2, 0xFF, 0x00,
 
 		NewArr,
 
@@ -1633,7 +1633,8 @@ func TestVM_Exec_NonValidOpCode(t *testing.T) {
 
 func TestVM_Exec_ArgumentsExceedInstructionSet(t *testing.T) {
 	code := []byte{
-		PushInt, 0x00, 0x00, PushInt, 0x0b, 0x01, 0x00, 0x03, 0x12, 0x05,
+		Push, 1, 0x00,
+		Push, 0x0c, 0x01, 0x00, 0x03, 0x12, 0x05,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1643,7 +1644,7 @@ func TestVM_Exec_ArgumentsExceedInstructionSet(t *testing.T) {
 
 	tos, _ := vm.evaluationStack.Pop()
 
-	expected := "pushint: Instruction set out of bounds"
+	expected := "push: Instruction set out of bounds"
 	actual := string(tos)
 	if actual != expected {
 		t.Errorf("Expected error message to be '%v' but was '%v'", expected, actual)
@@ -1652,7 +1653,7 @@ func TestVM_Exec_ArgumentsExceedInstructionSet(t *testing.T) {
 
 func TestVM_Exec_PopOnEmptyStack(t *testing.T) {
 	code := []byte{
-		PushInt, 0x00, 0x01,
+		Push, 1, 0x01,
 		SHA3,
 		Sub, 0x02, 0x03,
 	}
@@ -1674,7 +1675,7 @@ func TestVM_Exec_PopOnEmptyStack(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_InstructionSetOutOfBounds(t *testing.T) {
 	code := []byte{
-		PushInt, 0, 20,
+		Push, 1, 20,
 		Roll, 0,
 	}
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -49,6 +49,26 @@ func TestVM_Exec_GasConsumption(t *testing.T) {
 	}
 }
 
+func TestVM_Exec_PushInt(t *testing.T) {
+	code := []byte{
+		PushInt, 0, 0, // 0
+		PushInt, 1, 1, 1, // -1
+		PushInt, 1, 0, 255, // 255
+		PushInt, 2, 0, 1, 0, // 256
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, isSuccess)
+
+	expected := []int64{256, 255, -1, 0}
+
+	for _, i := range expected {
+		bint, _ := vm.PopSignedBigInt(OpCodes[PushInt])
+		assert.Equal(t, bint.Cmp(big.NewInt(i)), 0)
+	}
+}
+
 func TestVM_Exec_PushOutOfBounds(t *testing.T) {
 	code := []byte{
 		PushInt, 0, 125,

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -25,10 +25,10 @@ func TestVM_NewTestVM(t *testing.T) {
 
 func TestVM_Exec_GasConsumption(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 8,
-		PUSH, 1, 0, 8,
-		ADD,
-		HALT,
+		PushI, 1, 0, 8,
+		PushI, 1, 0, 8,
+		Add,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -49,9 +49,9 @@ func TestVM_Exec_GasConsumption(t *testing.T) {
 
 func TestVM_Exec_PushOutOfBounds(t *testing.T) {
 	code := []byte{
-		PUSH, 0, 125,
-		PUSH, 126, 12,
-		HALT,
+		PushI, 0, 125,
+		PushI, 126, 12,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -74,10 +74,10 @@ func TestVM_Exec_PushOutOfBounds(t *testing.T) {
 
 func TestVM_Exec_Addition(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 125,
-		PUSH, 2, 0, 168, 22,
-		ADD,
-		HALT,
+		PushI, 1, 0, 125,
+		PushI, 2, 0, 168, 22,
+		Add,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -97,10 +97,10 @@ func TestVM_Exec_Addition(t *testing.T) {
 
 func TestVM_Exec_Subtraction(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 6,
-		PUSH, 1, 0, 3,
-		SUB,
-		HALT,
+		PushI, 1, 0, 6,
+		PushI, 1, 0, 3,
+		Sub,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -120,10 +120,10 @@ func TestVM_Exec_Subtraction(t *testing.T) {
 
 func TestVM_Exec_SubtractionWithNegativeResults(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 3,
-		PUSH, 1, 0, 6,
-		SUB,
-		HALT,
+		PushI, 1, 0, 3,
+		PushI, 1, 0, 6,
+		Sub,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -147,10 +147,10 @@ func TestVM_Exec_SubtractionWithNegativeResults(t *testing.T) {
 
 func TestVM_Exec_Multiplication(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 5,
-		PUSH, 1, 0, 2,
-		MULT,
-		HALT,
+		PushI, 1, 0, 5,
+		PushI, 1, 0, 2,
+		Mul,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -170,10 +170,10 @@ func TestVM_Exec_Multiplication(t *testing.T) {
 
 func TestVM_Exec_Modulo(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 5,
-		PUSH, 1, 0, 2,
-		MOD,
-		HALT,
+		PushI, 1, 0, 5,
+		PushI, 1, 0, 2,
+		Mod,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -193,9 +193,9 @@ func TestVM_Exec_Modulo(t *testing.T) {
 
 func TestVM_Exec_Negate(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 5,
-		NEG,
-		HALT,
+		PushI, 1, 0, 5,
+		Neg,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -215,10 +215,10 @@ func TestVM_Exec_Negate(t *testing.T) {
 
 func TestVM_Exec_Division(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 6,
-		PUSH, 1, 0, 2,
-		DIV,
-		HALT,
+		PushI, 1, 0, 6,
+		PushI, 1, 0, 2,
+		Div,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -238,10 +238,10 @@ func TestVM_Exec_Division(t *testing.T) {
 
 func TestVM_Exec_DivisionByZero(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 6,
-		PUSH, 1, 0, 0,
-		DIV,
-		HALT,
+		PushI, 1, 0, 6,
+		PushI, 1, 0, 0,
+		Div,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -263,10 +263,10 @@ func TestVM_Exec_DivisionByZero(t *testing.T) {
 
 func TestVM_Exec_Eq(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 6,
-		PUSH, 1, 0, 6,
-		EQ,
-		HALT,
+		PushI, 1, 0, 6,
+		PushI, 1, 0, 6,
+		Eq,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -286,10 +286,10 @@ func TestVM_Exec_Eq(t *testing.T) {
 
 func TestVM_Exec_Neq(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 6,
-		PUSH, 1, 0, 5,
-		NEQ,
-		HALT,
+		PushI, 1, 0, 6,
+		PushI, 1, 0, 5,
+		NotEq,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -309,10 +309,10 @@ func TestVM_Exec_Neq(t *testing.T) {
 
 func TestVM_Exec_Lt(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 4,
-		PUSH, 1, 0, 6,
-		LT,
-		HALT,
+		PushI, 1, 0, 4,
+		PushI, 1, 0, 6,
+		Lt,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -333,10 +333,10 @@ func TestVM_Exec_Lt(t *testing.T) {
 
 func TestVM_Exec_Gt(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 6,
-		PUSH, 1, 0, 4,
-		GT,
-		HALT,
+		PushI, 1, 0, 6,
+		PushI, 1, 0, 4,
+		Gt,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -356,10 +356,10 @@ func TestVM_Exec_Gt(t *testing.T) {
 
 func TestVM_Exec_Lte_islower(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 4,
-		PUSH, 1, 0, 6,
-		LTE,
-		HALT,
+		PushI, 1, 0, 4,
+		PushI, 1, 0, 6,
+		LtEq,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -380,10 +380,10 @@ func TestVM_Exec_Lte_islower(t *testing.T) {
 
 func TestVM_Exec_Lte_isequals(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 6,
-		PUSH, 1, 0, 6,
-		LTE,
-		HALT,
+		PushI, 1, 0, 6,
+		PushI, 1, 0, 6,
+		LtEq,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -403,10 +403,10 @@ func TestVM_Exec_Lte_isequals(t *testing.T) {
 
 func TestVM_Exec_Gte_isGreater(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 6,
-		PUSH, 1, 0, 4,
-		GTE,
-		HALT,
+		PushI, 1, 0, 6,
+		PushI, 1, 0, 4,
+		GtEq,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -426,10 +426,10 @@ func TestVM_Exec_Gte_isGreater(t *testing.T) {
 
 func TestVM_Exec_Gte_isEqual(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 6,
-		PUSH, 1, 0, 6,
-		GTE,
-		HALT,
+		PushI, 1, 0, 6,
+		PushI, 1, 0, 6,
+		GtEq,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -449,9 +449,9 @@ func TestVM_Exec_Gte_isEqual(t *testing.T) {
 
 func TestVM_Exec_Shiftl(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 1,
-		SHIFTL, 3,
-		HALT,
+		PushI, 1, 0, 1,
+		ShiftL, 3,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -471,9 +471,9 @@ func TestVM_Exec_Shiftl(t *testing.T) {
 
 func TestVM_Exec_Shiftr(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 8,
-		SHIFTR, 3,
-		HALT,
+		PushI, 1, 0, 8,
+		ShiftR, 3,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -493,17 +493,17 @@ func TestVM_Exec_Shiftr(t *testing.T) {
 
 func TestVM_Exec_Jmpif(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 3,
-		PUSH, 1, 0, 4,
-		ADD,
-		PUSH, 1, 0, 20,
-		LT,
-		JMPIF, 0, 21,
-		PUSH, 0, 3,
-		NOP,
-		NOP,
-		NOP,
-		HALT,
+		PushI, 1, 0, 3,
+		PushI, 1, 0, 4,
+		Add,
+		PushI, 1, 0, 20,
+		Lt,
+		JmpTrue, 0, 21,
+		PushI, 0, 3,
+		NoOp,
+		NoOp,
+		NoOp,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -518,13 +518,13 @@ func TestVM_Exec_Jmpif(t *testing.T) {
 
 func TestVM_Exec_Jmp(t *testing.T) {
 	code := []byte{
-		PUSH, 0, 3,
-		JMP, 0, 14,
-		PUSH, 0, 4,
-		ADD,
-		PUSH, 0, 15,
-		ADD,
-		HALT,
+		PushI, 0, 3,
+		Jmp, 0, 14,
+		PushI, 0, 4,
+		Add,
+		PushI, 0, 15,
+		Add,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -544,16 +544,16 @@ func TestVM_Exec_Jmp(t *testing.T) {
 
 func TestVM_Exec_Call(t *testing.T) {
 	code := []byte{
-		PUSH, 0, 10,
-		PUSH, 0, 8,
-		CALL, 0, 13, 2,
-		HALT,
-		NOP,
-		NOP,
-		LOAD, 0, // Begin of called function at address 14
-		LOAD, 1,
-		SUB,
-		RET,
+		PushI, 0, 10,
+		PushI, 0, 8,
+		Call, 0, 13, 2,
+		Halt,
+		NoOp,
+		NoOp,
+		LoadLoc, 0, // Begin of called function at address 14
+		LoadLoc, 1,
+		Sub,
+		Ret,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -579,19 +579,19 @@ func TestVM_Exec_Call(t *testing.T) {
 
 func TestVM_Exec_Callif_true(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 10,
-		PUSH, 1, 0, 8,
-		PUSH, 1, 0, 10,
-		PUSH, 1, 0, 10,
-		EQ,
-		CALLIF, 0, 24, 2,
-		HALT,
-		NOP,
-		NOP,
-		LOAD, 0, // Begin of called function at address 20
-		LOAD, 1,
-		SUB,
-		RET,
+		PushI, 1, 0, 10,
+		PushI, 1, 0, 8,
+		PushI, 1, 0, 10,
+		PushI, 1, 0, 10,
+		Eq,
+		CallTrue, 0, 24, 2,
+		Halt,
+		NoOp,
+		NoOp,
+		LoadLoc, 0, // Begin of called function at address 20
+		LoadLoc, 1,
+		Sub,
+		Ret,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -617,19 +617,19 @@ func TestVM_Exec_Callif_true(t *testing.T) {
 
 func TestVM_Exec_Callif_false(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 10,
-		PUSH, 1, 0, 8,
-		PUSH, 1, 0, 10,
-		PUSH, 1, 0, 2,
-		EQ,
-		CALLIF, 0, 25, 2,
-		HALT,
-		NOP,
-		NOP,
-		LOAD, 0, // Begin of called function at address 21
-		LOAD, 1,
-		SUB,
-		RET,
+		PushI, 1, 0, 10,
+		PushI, 1, 0, 8,
+		PushI, 1, 0, 10,
+		PushI, 1, 0, 2,
+		Eq,
+		CallTrue, 0, 25, 2,
+		Halt,
+		NoOp,
+		NoOp,
+		LoadLoc, 0, // Begin of called function at address 21
+		LoadLoc, 1,
+		Sub,
+		Ret,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -655,9 +655,9 @@ func TestVM_Exec_Callif_false(t *testing.T) {
 
 func TestVM_Exec_TosSize(t *testing.T) {
 	code := []byte{
-		PUSH, 2, 10, 4, 5,
-		SIZE,
-		HALT,
+		PushI, 2, 10, 4, 5,
+		Size,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -680,10 +680,10 @@ func TestVM_Exec_TosSize(t *testing.T) {
 
 func TestVM_Exec_CallExt(t *testing.T) {
 	code := []byte{
-		PUSH, 0, 10,
-		PUSH, 0, 8,
-		CALLEXT, 227, 237, 86, 189, 8, 109, 137, 88, 72, 58, 18, 115, 79, 160, 174, 127, 92, 139, 177, 96, 239, 144, 146, 198, 126, 130, 237, 155, 25, 228, 199, 178, 41, 24, 45, 14, 2,
-		HALT,
+		PushI, 0, 10,
+		PushI, 0, 8,
+		CallExt, 227, 237, 86, 189, 8, 109, 137, 88, 72, 58, 18, 115, 79, 160, 174, 127, 92, 139, 177, 96, 239, 144, 146, 198, 126, 130, 237, 155, 25, 228, 199, 178, 41, 24, 45, 14, 2,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -694,10 +694,10 @@ func TestVM_Exec_CallExt(t *testing.T) {
 
 func TestVM_Exec_Sload(t *testing.T) {
 	code := []byte{
-		SLOAD, 1,
-		SLOAD, 0,
-		SLOAD, 2,
-		HALT,
+		LoadSt, 1,
+		LoadSt, 0,
+		LoadSt, 2,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -735,9 +735,9 @@ func TestVM_Exec_Sload(t *testing.T) {
 
 func TestVM_Exec_Sstore(t *testing.T) {
 	code := []byte{
-		PUSH, 9, 72, 105, 32, 84, 104, 101, 114, 101, 33, 33,
-		SSTORE, 0,
-		HALT,
+		PushI, 9, 72, 105, 32, 84, 104, 101, 114, 101, 33, 33,
+		StoreSt, 0,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -757,8 +757,8 @@ func TestVM_Exec_Sstore(t *testing.T) {
 
 func TestVM_Exec_Address(t *testing.T) {
 	code := []byte{
-		ADDRESS,
-		HALT,
+		Address,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -785,8 +785,8 @@ func TestVM_Exec_Address(t *testing.T) {
 
 func TestVM_Exec_Balance(t *testing.T) {
 	code := []byte{
-		BALANCE,
-		HALT,
+		Balance,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -811,8 +811,8 @@ func TestVM_Exec_Balance(t *testing.T) {
 
 func TestVM_Exec_Caller(t *testing.T) {
 	code := []byte{
-		CALLER,
-		HALT,
+		Caller,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -840,8 +840,8 @@ func TestVM_Exec_Caller(t *testing.T) {
 
 func TestVM_Exec_Callval(t *testing.T) {
 	code := []byte{
-		CALLVAL,
-		HALT,
+		CallVal,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -865,8 +865,8 @@ func TestVM_Exec_Callval(t *testing.T) {
 
 func TestVM_Exec_Calldata(t *testing.T) {
 	code := []byte{
-		CALLDATA,
-		HALT,
+		CallData,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -902,9 +902,9 @@ func TestVM_Exec_Calldata(t *testing.T) {
 
 func TestVM_Exec_Sha3(t *testing.T) {
 	code := []byte{
-		PUSH, 0, 3,
+		PushI, 0, 3,
 		SHA3,
-		HALT,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -921,13 +921,13 @@ func TestVM_Exec_Sha3(t *testing.T) {
 
 func TestVM_Exec_Roll(t *testing.T) {
 	code := []byte{
-		PUSH, 0, 3,
-		PUSH, 0, 4,
-		PUSH, 0, 5,
-		PUSH, 0, 6,
-		PUSH, 0, 7,
-		ROLL, 2,
-		HALT,
+		PushI, 0, 3,
+		PushI, 0, 4,
+		PushI, 0, 5,
+		PushI, 0, 6,
+		PushI, 0, 7,
+		Roll, 2,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -946,8 +946,8 @@ func TestVM_Exec_Roll(t *testing.T) {
 
 func TestVM_Exec_NewMap(t *testing.T) {
 	code := []byte{
-		NEWMAP,
-		HALT,
+		NewMap,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -969,26 +969,26 @@ func TestVM_Exec_NewMap(t *testing.T) {
 
 func TestVM_Exec_MapHasKey_true(t *testing.T) {
 	code := []byte{
-		PUSH, 0x00, 0x01, //The key for MAPGETVAL
+		PushI, 0x00, 0x01, //The key for MAPGETVAL
 
-		PUSH, 0x01, 0x48, 0x48,
-		PUSH, 0x00, 0x01,
+		PushI, 0x01, 0x48, 0x48,
+		PushI, 0x00, 0x01,
 
-		PUSH, 0x01, 0x69, 0x69,
-		PUSH, 0x00, 0x02,
+		PushI, 0x01, 0x69, 0x69,
+		PushI, 0x00, 0x02,
 
-		PUSH, 0x01, 0x48, 0x69,
-		PUSH, 0x00, 0x03,
+		PushI, 0x01, 0x48, 0x69,
+		PushI, 0x00, 0x03,
 
-		NEWMAP,
+		NewMap,
 
-		MAPPUSH,
-		MAPPUSH,
-		MAPPUSH,
+		MapPush,
+		MapPush,
+		MapPush,
 
-		MAPHASKEY,
+		MapHasKey,
 
-		HALT,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1015,26 +1015,26 @@ func TestVM_Exec_MapHasKey_true(t *testing.T) {
 
 func TestVM_Exec_MapHasKey_false(t *testing.T) {
 	code := []byte{
-		PUSH, 0x00, 0x06, //The key for MAPGETVAL
+		PushI, 0x00, 0x06, //The key for MAPGETVAL
 
-		PUSH, 0x01, 0x48, 0x48,
-		PUSH, 0x00, 0x01,
+		PushI, 0x01, 0x48, 0x48,
+		PushI, 0x00, 0x01,
 
-		PUSH, 0x01, 0x69, 0x69,
-		PUSH, 0x00, 0x02,
+		PushI, 0x01, 0x69, 0x69,
+		PushI, 0x00, 0x02,
 
-		PUSH, 0x01, 0x48, 0x69,
-		PUSH, 0x00, 0x03,
+		PushI, 0x01, 0x48, 0x69,
+		PushI, 0x00, 0x03,
 
-		NEWMAP,
+		NewMap,
 
-		MAPPUSH,
-		MAPPUSH,
-		MAPPUSH,
+		MapPush,
+		MapPush,
+		MapPush,
 
-		MAPHASKEY,
+		MapHasKey,
 
-		HALT,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1061,11 +1061,11 @@ func TestVM_Exec_MapHasKey_false(t *testing.T) {
 
 func TestVM_Exec_MapPush(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 72, 105,
-		PUSH, 0, 0x03,
-		NEWMAP,
-		MAPPUSH,
-		HALT,
+		PushI, 1, 72, 105,
+		PushI, 0, 0x03,
+		NewMap,
+		MapPush,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1107,26 +1107,26 @@ func TestVM_Exec_MapPush(t *testing.T) {
 
 func TestVM_Exec_MapGetVAL(t *testing.T) {
 	code := []byte{
-		PUSH, 0x00, 0x01, //The key for MAPGETVAL
+		PushI, 0x00, 0x01, //The key for MAPGETVAL
 
-		PUSH, 0x01, 0x48, 0x48,
-		PUSH, 0x00, 0x01,
+		PushI, 0x01, 0x48, 0x48,
+		PushI, 0x00, 0x01,
 
-		PUSH, 0x01, 0x69, 0x69,
-		PUSH, 0x00, 0x02,
+		PushI, 0x01, 0x69, 0x69,
+		PushI, 0x00, 0x02,
 
-		PUSH, 0x01, 0x48, 0x69,
-		PUSH, 0x00, 0x03,
+		PushI, 0x01, 0x48, 0x69,
+		PushI, 0x00, 0x03,
 
-		NEWMAP,
+		NewMap,
 
-		MAPPUSH,
-		MAPPUSH,
-		MAPPUSH,
+		MapPush,
+		MapPush,
+		MapPush,
 
-		MAPGETVAL,
+		MapGetVal,
 
-		HALT,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1153,23 +1153,23 @@ func TestVM_Exec_MapGetVAL(t *testing.T) {
 
 func TestVM_Exec_MapSetVal(t *testing.T) {
 	code := []byte{
-		PUSH, 0x01, 0x55, 0x55, //Value to be reset by MAPSETVAL
-		PUSH, 0x00, 0x03,
+		PushI, 0x01, 0x55, 0x55, //Value to be reset by MAPSETVAL
+		PushI, 0x00, 0x03,
 
-		PUSH, 0x01, 0x48, 0x69,
-		PUSH, 0x00, 0x03,
+		PushI, 0x01, 0x48, 0x69,
+		PushI, 0x00, 0x03,
 
-		PUSH, 0x01, 0x69, 0x69,
-		PUSH, 0x00, 0x02,
+		PushI, 0x01, 0x69, 0x69,
+		PushI, 0x00, 0x02,
 
-		NEWMAP,
+		NewMap,
 
-		MAPPUSH,
-		MAPPUSH,
+		MapPush,
+		MapPush,
 
-		MAPSETVAL,
+		MapSetVal,
 
-		HALT,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1207,25 +1207,25 @@ func TestVM_Exec_MapSetVal(t *testing.T) {
 
 func TestVM_Exec_MapRemove(t *testing.T) {
 	code := []byte{
-		PUSH, 0x00, 0x03, // The Key to be removed with MAPREMOVE
+		PushI, 0x00, 0x03, // The Key to be removed with MAPREMOVE
 
-		PUSH, 0x01, 0x48, 0x69,
-		PUSH, 0x00, 0x03,
+		PushI, 0x01, 0x48, 0x69,
+		PushI, 0x00, 0x03,
 
-		PUSH, 0x01, 0x48, 0x48,
-		PUSH, 0x00, 0x01,
+		PushI, 0x01, 0x48, 0x48,
+		PushI, 0x00, 0x01,
 
-		PUSH, 0x01, 0x69, 0x69,
-		PUSH, 0x00, 0x02,
+		PushI, 0x01, 0x69, 0x69,
+		PushI, 0x00, 0x02,
 
-		NEWMAP,
+		NewMap,
 
-		MAPPUSH,
-		MAPPUSH,
-		MAPPUSH,
+		MapPush,
+		MapPush,
+		MapPush,
 
-		MAPREMOVE,
-		HALT,
+		MapRemove,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1264,8 +1264,8 @@ func TestVM_Exec_MapRemove(t *testing.T) {
 
 func TestVM_Exec_NewArr(t *testing.T) {
 	code := []byte{
-		NEWARR,
-		HALT,
+		NewArr,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1291,10 +1291,10 @@ func TestVM_Exec_NewArr(t *testing.T) {
 
 func TestVM_Exec_ArrAppend(t *testing.T) {
 	code := []byte{
-		PUSH, 0x01, 0xFF, 0x00,
-		NEWARR,
-		ARRAPPEND,
-		HALT,
+		PushI, 0x01, 0xFF, 0x00,
+		NewArr,
+		ArrAppend,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1320,17 +1320,17 @@ func TestVM_Exec_ArrAppend(t *testing.T) {
 
 func TestVM_Exec_ArrInsert(t *testing.T) {
 	code := []byte{
-		PUSH, 0x01, 0x00, 0x00,
-		PUSH, 0x01, 0x00, 0x00,
+		PushI, 0x01, 0x00, 0x00,
+		PushI, 0x01, 0x00, 0x00,
 
-		PUSH, 0x01, 0xFF, 0x00,
+		PushI, 0x01, 0xFF, 0x00,
 
-		PUSH, 0x01, 0xFF, 0x00,
-		NEWARR,
-		ARRAPPEND,
-		ARRAPPEND,
-		ARRINSERT,
-		HALT,
+		PushI, 0x01, 0xFF, 0x00,
+		NewArr,
+		ArrAppend,
+		ArrAppend,
+		ArrInsert,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1361,18 +1361,18 @@ func TestVM_Exec_ArrInsert(t *testing.T) {
 
 func TestVM_Exec_ArrRemove(t *testing.T) {
 	code := []byte{
-		PUSH, 0x01, 0x01, 0x00, //Index of element to remove
-		PUSH, 0x01, 0xBB, 0x00,
-		PUSH, 0x01, 0xAA, 0x00,
-		PUSH, 0x01, 0xFF, 0x00,
+		PushI, 0x01, 0x01, 0x00, //Index of element to remove
+		PushI, 0x01, 0xBB, 0x00,
+		PushI, 0x01, 0xAA, 0x00,
+		PushI, 0x01, 0xFF, 0x00,
 
-		NEWARR,
+		NewArr,
 
-		ARRAPPEND,
-		ARRAPPEND,
-		ARRAPPEND,
-		ARRREMOVE,
-		HALT,
+		ArrAppend,
+		ArrAppend,
+		ArrAppend,
+		ArrRemove,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1418,19 +1418,19 @@ func TestVM_Exec_ArrRemove(t *testing.T) {
 
 func TestVM_Exec_ArrAt(t *testing.T) {
 	code := []byte{
-		PUSH, 0x01, 0x02, 0x00, // index for ARRAT
-		PUSH, 0x01, 0xBB, 0x00,
-		PUSH, 0x01, 0xAA, 0x00,
-		PUSH, 0x01, 0xFF, 0x00,
+		PushI, 0x01, 0x02, 0x00, // index for ARRAT
+		PushI, 0x01, 0xBB, 0x00,
+		PushI, 0x01, 0xAA, 0x00,
+		PushI, 0x01, 0xFF, 0x00,
 
-		NEWARR,
+		NewArr,
 
-		ARRAPPEND,
-		ARRAPPEND,
-		ARRAPPEND,
+		ArrAppend,
+		ArrAppend,
+		ArrAppend,
 
-		ARRAT,
-		HALT,
+		ArrAt,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1478,7 +1478,7 @@ func TestVM_Exec_NonValidOpCode(t *testing.T) {
 
 func TestVM_Exec_ArgumentsExceedInstructionSet(t *testing.T) {
 	code := []byte{
-		PUSH, 0x00, 0x00, PUSH, 0x0b, 0x01, 0x00, 0x03, 0x12, 0x05,
+		PushI, 0x00, 0x00, PushI, 0x0b, 0x01, 0x00, 0x03, 0x12, 0x05,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1497,9 +1497,9 @@ func TestVM_Exec_ArgumentsExceedInstructionSet(t *testing.T) {
 
 func TestVM_Exec_PopOnEmptyStack(t *testing.T) {
 	code := []byte{
-		PUSH, 0x00, 0x01,
+		PushI, 0x00, 0x01,
 		SHA3,
-		SUB, 0x02, 0x03,
+		Sub, 0x02, 0x03,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1519,8 +1519,8 @@ func TestVM_Exec_PopOnEmptyStack(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_InstructionSetOutOfBounds(t *testing.T) {
 	code := []byte{
-		PUSH, 0, 20,
-		ROLL, 0,
+		PushI, 0, 20,
+		Roll, 0,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1539,7 +1539,7 @@ func TestVM_Exec_FuzzReproduction_InstructionSetOutOfBounds(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_InstructionSetOutOfBounds2(t *testing.T) {
 	code := []byte{
-		CALLEXT, 231,
+		CallExt, 231,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1559,7 +1559,7 @@ func TestVM_Exec_FuzzReproduction_InstructionSetOutOfBounds2(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_IndexOutOfBounds1(t *testing.T) {
 	code := []byte{
-		SLOAD, 0, 0, 33,
+		LoadSt, 0, 0, 33,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1578,7 +1578,7 @@ func TestVM_Exec_FuzzReproduction_IndexOutOfBounds1(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_IndexOutOfBounds2(t *testing.T) {
 	code := []byte{
-		PUSH, 4, 46, 110, 66, 50, 255, SSTORE, 123, 119,
+		PushI, 4, 46, 110, 66, 50, 255, StoreSt, 123, 119,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1599,23 +1599,23 @@ func TestVM_Exec_FuzzReproduction_IndexOutOfBounds2(t *testing.T) {
 func TestVM_Exec_FunctionCallSub(t *testing.T) {
 	code := []byte{
 		// start ABI
-		CALLDATA,
-		DUP,
-		PUSH, 1, 0, 1,
-		EQ,
-		JMPIF, 0, 20,
-		DUP,
-		PUSH, 1, 0, 2,
-		EQ,
-		JMPIF, 0, 23,
-		HALT,
+		CallData,
+		Dup,
+		PushI, 1, 0, 1,
+		Eq,
+		JmpTrue, 0, 20,
+		Dup,
+		PushI, 1, 0, 2,
+		Eq,
+		JmpTrue, 0, 23,
+		Halt,
 		// end ABI
-		POP,
-		SUB,
-		HALT,
-		POP,
-		ADD,
-		HALT,
+		Pop,
+		Sub,
+		Halt,
+		Pop,
+		Add,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1642,23 +1642,23 @@ func TestVM_Exec_FunctionCallSub(t *testing.T) {
 func TestVM_Exec_FunctionCall(t *testing.T) {
 	code := []byte{
 		// start ABI
-		CALLDATA,
-		DUP,
-		PUSH, 1, 0, 1,
-		EQ,
-		JMPIF, 0, 20,
-		DUP,
-		PUSH, 1, 0, 2,
-		EQ,
-		JMPIF, 0, 23,
-		HALT,
+		CallData,
+		Dup,
+		PushI, 1, 0, 1,
+		Eq,
+		JmpTrue, 0, 20,
+		Dup,
+		PushI, 1, 0, 2,
+		Eq,
+		JmpTrue, 0, 23,
+		Halt,
 		// end ABI
-		POP,
-		SUB,
-		HALT,
-		POP,
-		ADD,
-		HALT,
+		Pop,
+		Sub,
+		Halt,
+		Pop,
+		Add,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1684,7 +1684,7 @@ func TestVM_Exec_FunctionCall(t *testing.T) {
 
 func TestVM_Exec_GithubIssue13(t *testing.T) {
 	code := []byte{
-		ADDRESS, ARRAT,
+		Address, ArrAt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1703,7 +1703,7 @@ func TestVM_Exec_GithubIssue13(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_ContextOpCode1(t *testing.T) {
 	code := []byte{
-		CALLER, CALLER, ARRAPPEND,
+		Caller, Caller, ArrAppend,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1723,7 +1723,7 @@ func TestVM_Exec_FuzzReproduction_ContextOpCode1(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_ContextOpCode2(t *testing.T) {
 	code := []byte{
-		ADDRESS, CALLER, ARRAPPEND,
+		Address, Caller, ArrAppend,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1743,7 +1743,7 @@ func TestVM_Exec_FuzzReproduction_ContextOpCode2(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_EdgecaseLastOpcodePlusOne(t *testing.T) {
 	code := []byte{
-		HALT + 1,
+		Halt + 1,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1762,10 +1762,10 @@ func TestVM_Exec_FuzzReproduction_EdgecaseLastOpcodePlusOne(t *testing.T) {
 
 func TestVM_PopBytes(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 8,
-		PUSH, 1, 0, 8,
-		ADD,
-		HALT,
+		PushI, 1, 0, 8,
+		PushI, 1, 0, 8,
+		Add,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1819,12 +1819,12 @@ func TestVM_FuzzTest_Reproduction_IndexOutOfRange(t *testing.T) {
 
 func TestVM_GasCalculation(t *testing.T) {
 	code := []byte{
-		PUSH, 64, 0, 8, 179, 91, 9, 9, 6, 136, 231, 56, 7, 146, 99, 170, 98, 183, 40, 118, 185, 95,
+		PushI, 64, 0, 8, 179, 91, 9, 9, 6, 136, 231, 56, 7, 146, 99, 170, 98, 183, 40, 118, 185, 95,
 		106, 14, 143, 25, 99, 79, 76, 222, 197, 5, 218, 90, 216, 47, 218, 74, 53, 139, 62, 28, 104,
 		180, 139, 65, 103, 193, 244, 169, 85, 39, 160, 218, 158, 207, 118, 37, 78, 42, 186, 64, 4, 70, 70, 190, 177,
-		PUSH, 1, 0, 8,
-		ADD,
-		HALT,
+		PushI, 1, 0, 8,
+		Add,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1844,10 +1844,10 @@ func TestVM_GasCalculation(t *testing.T) {
 
 func TestVM_PopBytesOutOfGas(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 8,
-		PUSH, 1, 0, 8,
-		ADD,
-		HALT,
+		PushI, 1, 0, 8,
+		PushI, 1, 0, 8,
+		Add,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1969,75 +1969,75 @@ func modularExpContract(base big.Int, exponent big.Int, modulus big.Int) []byte 
 	addressForLoop := UInt16ToByteArray(uint16(20) + uint16(len(baseVal)) + uint16(len(modulusVal)) + uint16(len(exponentVal)))
 
 	contract := []byte{
-		PUSH,
+		PushI,
 	}
 	contract = append(contract, baseVal...)
-	contract = append(contract, PUSH)
+	contract = append(contract, PushI)
 	contract = append(contract, modulusVal...)
 	contract = append(contract, []byte{
-		DUP,
-		PUSH, 1, 0, 0,
-		EQ,
-		JMPIF,
+		Dup,
+		PushI, 1, 0, 0,
+		Eq,
+		JmpTrue,
 	}...)
 	contract = append(contract, addressBeforeExp[1])
 	contract = append(contract, addressBeforeExp[0])
 	contract = append(contract, []byte{
-		PUSH, 1, 0, 1, // Counter (c)
-		PUSH, 1, 0, 0, //i
-		PUSH,
+		PushI, 1, 0, 1, // Counter (c)
+		PushI, 1, 0, 0, //i
+		PushI,
 	}...)
 	contract = append(contract, exponentVal...)
 	contract = append(contract, []byte{
 		//LOOP start
 		//Duplicate arguments
-		ROLL, 2,
-		DUP, //Stack: [[0 11 75] [0 11 75] [0 13] [0 0] [0 1] [0 4]]
-		ROLL, 4,
-		DUP, // STACK Stack: [[04] [0 4] [0 11 75] [0 11 75] [0 13] [0 0] [0 1]]
+		Roll, 2,
+		Dup, //Stack: [[0 11 75] [0 11 75] [0 13] [0 0] [0 1] [0 4]]
+		Roll, 4,
+		Dup, // STACK Stack: [[04] [0 4] [0 11 75] [0 11 75] [0 13] [0 0] [0 1]]
 		// PUT in order
-		ROLL, 1, //Stack: [[0 11 75] [0 4] [0 4] [0 11 75] [0 13] [0 0] [0 1]]
-		ROLL, 4, //Stack: [[0 0] [0 11 75] [0 4] [0 4] [0 11 75] [0 13] [0 1]]
-		ROLL, 4, //Stack: [[0 13] [0 0] [0 11 75] [0 4] [0 4] [0 11 75] [0 1]]
-		ROLL, 3, //Stack: [[0 4] [0 13] [0 0] [0 11 75] [0 4] [0 11 75] [0 1]]
-		ROLL, 4, //Stack: [[0 11 75] [0 4] [0 13] [0 0] [0 11 75] [0 4] [0 1]]
-		ROLL, 5, //Stack: [[0 1] [0 11 75] [0 4] [0 13] [0 0] [0 11 75] [0 4]]
+		Roll, 1, //Stack: [[0 11 75] [0 4] [0 4] [0 11 75] [0 13] [0 0] [0 1]]
+		Roll, 4, //Stack: [[0 0] [0 11 75] [0 4] [0 4] [0 11 75] [0 13] [0 1]]
+		Roll, 4, //Stack: [[0 13] [0 0] [0 11 75] [0 4] [0 4] [0 11 75] [0 1]]
+		Roll, 3, //Stack: [[0 4] [0 13] [0 0] [0 11 75] [0 4] [0 11 75] [0 1]]
+		Roll, 4, //Stack: [[0 11 75] [0 4] [0 13] [0 0] [0 11 75] [0 4] [0 1]]
+		Roll, 5, //Stack: [[0 1] [0 11 75] [0 4] [0 13] [0 0] [0 11 75] [0 4]]
 		// Order: counter, modulus, base, exp, i, modulus, base
-		CALL,
+		Call,
 	}...)
 	contract = append(contract, byte(addressAfterExp[1]))
 	contract = append(contract, byte(addressAfterExp[0]))
 	contract = append(contract, []byte{
 		3,
 		// PUT in order
-		ROLL, 1,
-		ROLL, 1,
+		Roll, 1,
+		Roll, 1,
 
 		// Order: exp, i - counter, modulus, base,
-		DUP,
-		ROLL, 1,
-		PUSH, 1, 0, 1,
-		ADD,
-		DUP,
-		ROLL, 1,
-		ROLL, 1,
-		ROLL, 2,
-		LT,
-		JMPIF,
+		Dup,
+		Roll, 1,
+		PushI, 1, 0, 1,
+		Add,
+		Dup,
+		Roll, 1,
+		Roll, 1,
+		Roll, 2,
+		Lt,
+		JmpTrue,
 	}...)
 	contract = append(contract, addressForLoop[1])
 	contract = append(contract, addressForLoop[0])
 	contract = append(contract, []byte{
 		// LOOP END
-		HALT,
+		Halt,
 
 		// FUNCTION Order: c, modulus, base,
-		LOAD, 2,
-		LOAD, 0,
-		MULT,
-		LOAD, 1,
-		MOD,
-		RET,
+		LoadLoc, 2,
+		LoadLoc, 0,
+		Mul,
+		LoadLoc, 1,
+		Mod,
+		Ret,
 	}...)
 
 	return contract
@@ -2045,22 +2045,22 @@ func modularExpContract(base big.Int, exponent big.Int, modulus big.Int) []byte 
 
 func TestVm_Exec_Loop(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 0, //i
-		PUSH, 1, 0, 13, // Exp
+		PushI, 1, 0, 0, //i
+		PushI, 1, 0, 13, // Exp
 
 		// Order: exp, i
-		DUP,
-		ROLL, 1,
-		PUSH, 1, 0, 1,
-		ADD,
-		DUP,
-		ROLL, 1,
-		ROLL, 1,
-		ROLL, 2,
-		LT,
-		JMPIF, 0, 8, // Adjust address
+		Dup,
+		Roll, 1,
+		PushI, 1, 0, 1,
+		Add,
+		Dup,
+		Roll, 1,
+		Roll, 1,
+		Roll, 2,
+		Lt,
+		JmpTrue, 0, 8, // Adjust address
 		// LOOP END
-		HALT,
+		Halt,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -2079,58 +2079,58 @@ func TestVm_Exec_Loop(t *testing.T) {
 
 func TestVm_Exec_ModularExponentiation_ContractImplementation(t *testing.T) {
 	code := []byte{
-		PUSH, 1, 0, 4, // Base
-		PUSH, 2, 0, 1, 241, // Modulus
+		PushI, 1, 0, 4, // Base
+		PushI, 2, 0, 1, 241, // Modulus
 		// IF modulus equals 0
-		DUP,
-		PUSH, 1, 0, 0,
-		EQ,
-		JMPIF, 0, 46, // Adjust address
+		Dup,
+		PushI, 1, 0, 0,
+		Eq,
+		JmpTrue, 0, 46, // Adjust address
 
-		PUSH, 1, 0, 1, // Counter (c)
-		PUSH, 1, 0, 0, //i
-		PUSH, 1, 0, 13, // Exp
+		PushI, 1, 0, 1, // Counter (c)
+		PushI, 1, 0, 0, //i
+		PushI, 1, 0, 13, // Exp
 
 		//LOOP start
 		//Duplicate arguments
-		ROLL, 2,
-		DUP, //Stack: [[0 11 75] [0 11 75] [0 13] [0 0] [0 1] [0 4]]
-		ROLL, 4,
-		DUP, // STACK Stack: [[04] [0 4] [0 11 75] [0 11 75] [0 13] [0 0] [0 1]]
+		Roll, 2,
+		Dup, //Stack: [[0 11 75] [0 11 75] [0 13] [0 0] [0 1] [0 4]]
+		Roll, 4,
+		Dup, // STACK Stack: [[04] [0 4] [0 11 75] [0 11 75] [0 13] [0 0] [0 1]]
 		// PUT in order
-		ROLL, 1, //Stack: [[0 11 75] [0 4] [0 4] [0 11 75] [0 13] [0 0] [0 1]]
-		ROLL, 4, //Stack: [[0 0] [0 11 75] [0 4] [0 4] [0 11 75] [0 13] [0 1]]
-		ROLL, 4, //Stack: [[0 13] [0 0] [0 11 75] [0 4] [0 4] [0 11 75] [0 1]]
-		ROLL, 3, //Stack: [[0 4] [0 13] [0 0] [0 11 75] [0 4] [0 11 75] [0 1]]
-		ROLL, 4, //Stack: [[0 11 75] [0 4] [0 13] [0 0] [0 11 75] [0 4] [0 1]]
-		ROLL, 5, //Stack: [[0 1] [0 11 75] [0 4] [0 13] [0 0] [0 11 75] [0 4]]
+		Roll, 1, //Stack: [[0 11 75] [0 4] [0 4] [0 11 75] [0 13] [0 0] [0 1]]
+		Roll, 4, //Stack: [[0 0] [0 11 75] [0 4] [0 4] [0 11 75] [0 13] [0 1]]
+		Roll, 4, //Stack: [[0 13] [0 0] [0 11 75] [0 4] [0 4] [0 11 75] [0 1]]
+		Roll, 3, //Stack: [[0 4] [0 13] [0 0] [0 11 75] [0 4] [0 11 75] [0 1]]
+		Roll, 4, //Stack: [[0 11 75] [0 4] [0 13] [0 0] [0 11 75] [0 4] [0 1]]
+		Roll, 5, //Stack: [[0 1] [0 11 75] [0 4] [0 13] [0 0] [0 11 75] [0 4]]
 		// Order: counter, modulus, base, exp, i, modulus, base
-		CALL, 0, 76, 3,
+		Call, 0, 76, 3,
 		// PUT in order
-		ROLL, 1,
-		ROLL, 1,
+		Roll, 1,
+		Roll, 1,
 
 		// Order: exp, i - counter, modulus, base,
-		DUP,
-		ROLL, 1,
-		PUSH, 1, 0, 1,
-		ADD,
-		DUP,
-		ROLL, 1,
-		ROLL, 1,
-		ROLL, 2,
-		LT,
-		JMPIF, 0, 30, // Adjust address
+		Dup,
+		Roll, 1,
+		PushI, 1, 0, 1,
+		Add,
+		Dup,
+		Roll, 1,
+		Roll, 1,
+		Roll, 2,
+		Lt,
+		JmpTrue, 0, 30, // Adjust address
 		// LOOP END
-		HALT,
+		Halt,
 
 		// FUNCTION Order: c, modulus, base,
-		LOAD, 2,
-		LOAD, 0,
-		MULT,
-		LOAD, 1,
-		MOD,
-		RET,
+		LoadLoc, 2,
+		LoadLoc, 0,
+		Mul,
+		LoadLoc, 1,
+		Mod,
+		Ret,
 	}
 
 	vm := NewTestVM([]byte{})

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -168,6 +168,45 @@ func TestVM_Exec_PushStr_Invalid(t *testing.T) {
 	assert.Equal(t, string(tos), "pushstr: invalid ASCII code 200")
 }
 
+func TestVM_Exec_Push_Empty(t *testing.T) {
+	code := []byte{
+		Push, 0, // []
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assertBytes(t, tos)
+}
+
+func TestVM_Exec_Push(t *testing.T) {
+	code := []byte{
+		Push, 2, 128, 255, // [128, 255]
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assertBytes(t, tos, 128, 255)
+}
+
+func TestVM_Exec_Push_InvalidLength(t *testing.T) {
+	code := []byte{
+		Push, 2, 128, // [128]
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, !isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assert.Equal(t, string(tos), "push: Instruction set out of bounds")
+}
+
 func TestVM_Exec_Addition(t *testing.T) {
 	code := []byte{
 		PushInt, 1, 0, 125,

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -90,6 +90,45 @@ func TestVM_Exec_PushBool(t *testing.T) {
 	assertBytes(t, tos, 0)
 }
 
+func TestVM_Exec_PushBool_Invalid(t *testing.T) {
+	code := []byte{
+		PushBool, 5,
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, !isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assert.Equal(t, string(tos), "pushbool: invalid bool value 5")
+}
+
+func TestVM_Exec_PushChar(t *testing.T) {
+	code := []byte{
+		PushChar, 104, // 'h'
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assertBytes(t, tos, 104)
+}
+
+func TestVM_Exec_PushChar_Invalid(t *testing.T) {
+	code := []byte{
+		PushChar, 128,
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, !isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assert.Equal(t, string(tos), "pushchar: invalid ASCII code 128")
+}
+
 func TestVM_Exec_Addition(t *testing.T) {
 	code := []byte{
 		PushInt, 1, 0, 125,

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/bazo-blockchain/bazo-miner/protocol"
+	"gotest.tools/assert"
 )
 
 func TestVM_NewTestVM(t *testing.T) {
@@ -25,8 +26,8 @@ func TestVM_NewTestVM(t *testing.T) {
 
 func TestVM_Exec_GasConsumption(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 8,
-		PushI, 1, 0, 8,
+		PushInt, 1, 0, 8,
+		PushInt, 1, 0, 8,
 		Add,
 		Halt,
 	}
@@ -36,7 +37,8 @@ func TestVM_Exec_GasConsumption(t *testing.T) {
 	mc.Fee = 30
 	vm.context = mc
 
-	vm.Exec(false)
+	success := vm.Exec(false)
+	assert.Assert(t, success)
 
 	ba, _ := vm.evaluationStack.Pop()
 	expected := 16
@@ -49,8 +51,8 @@ func TestVM_Exec_GasConsumption(t *testing.T) {
 
 func TestVM_Exec_PushOutOfBounds(t *testing.T) {
 	code := []byte{
-		PushI, 0, 125,
-		PushI, 126, 12,
+		PushInt, 0, 125,
+		PushInt, 126, 12,
 		Halt,
 	}
 
@@ -65,17 +67,33 @@ func TestVM_Exec_PushOutOfBounds(t *testing.T) {
 	}
 
 	actual := string(tos)
-	expected := "push: Instruction set out of bounds"
+	expected := "pushint: Instruction set out of bounds"
 
 	if actual != expected {
 		t.Errorf("Expected '%v' to be returned but got '%v'", expected, actual)
 	}
 }
 
+func TestVM_Exec_PushBool(t *testing.T) {
+	code := []byte{
+		PushBool, 0,
+		PushBool, 1,
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assertBytes(t, tos, 1)
+	tos, _ = vm.evaluationStack.Pop()
+	assertBytes(t, tos, 0)
+}
+
 func TestVM_Exec_Addition(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 125,
-		PushI, 2, 0, 168, 22,
+		PushInt, 1, 0, 125,
+		PushInt, 2, 0, 168, 22,
 		Add,
 		Halt,
 	}
@@ -97,8 +115,8 @@ func TestVM_Exec_Addition(t *testing.T) {
 
 func TestVM_Exec_Subtraction(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 6,
-		PushI, 1, 0, 3,
+		PushInt, 1, 0, 6,
+		PushInt, 1, 0, 3,
 		Sub,
 		Halt,
 	}
@@ -120,8 +138,8 @@ func TestVM_Exec_Subtraction(t *testing.T) {
 
 func TestVM_Exec_SubtractionWithNegativeResults(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 3,
-		PushI, 1, 0, 6,
+		PushInt, 1, 0, 3,
+		PushInt, 1, 0, 6,
 		Sub,
 		Halt,
 	}
@@ -147,8 +165,8 @@ func TestVM_Exec_SubtractionWithNegativeResults(t *testing.T) {
 
 func TestVM_Exec_Multiplication(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 5,
-		PushI, 1, 0, 2,
+		PushInt, 1, 0, 5,
+		PushInt, 1, 0, 2,
 		Mul,
 		Halt,
 	}
@@ -170,8 +188,8 @@ func TestVM_Exec_Multiplication(t *testing.T) {
 
 func TestVM_Exec_Modulo(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 5,
-		PushI, 1, 0, 2,
+		PushInt, 1, 0, 5,
+		PushInt, 1, 0, 2,
 		Mod,
 		Halt,
 	}
@@ -193,7 +211,7 @@ func TestVM_Exec_Modulo(t *testing.T) {
 
 func TestVM_Exec_Negate(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 5,
+		PushInt, 1, 0, 5,
 		Neg,
 		Halt,
 	}
@@ -215,8 +233,8 @@ func TestVM_Exec_Negate(t *testing.T) {
 
 func TestVM_Exec_Division(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 6,
-		PushI, 1, 0, 2,
+		PushInt, 1, 0, 6,
+		PushInt, 1, 0, 2,
 		Div,
 		Halt,
 	}
@@ -238,8 +256,8 @@ func TestVM_Exec_Division(t *testing.T) {
 
 func TestVM_Exec_DivisionByZero(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 6,
-		PushI, 1, 0, 0,
+		PushInt, 1, 0, 6,
+		PushInt, 1, 0, 0,
 		Div,
 		Halt,
 	}
@@ -263,8 +281,8 @@ func TestVM_Exec_DivisionByZero(t *testing.T) {
 
 func TestVM_Exec_Eq(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 6,
-		PushI, 1, 0, 6,
+		PushInt, 1, 0, 6,
+		PushInt, 1, 0, 6,
 		Eq,
 		Halt,
 	}
@@ -286,8 +304,8 @@ func TestVM_Exec_Eq(t *testing.T) {
 
 func TestVM_Exec_Neq(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 6,
-		PushI, 1, 0, 5,
+		PushInt, 1, 0, 6,
+		PushInt, 1, 0, 5,
 		NotEq,
 		Halt,
 	}
@@ -309,8 +327,8 @@ func TestVM_Exec_Neq(t *testing.T) {
 
 func TestVM_Exec_Lt(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 4,
-		PushI, 1, 0, 6,
+		PushInt, 1, 0, 4,
+		PushInt, 1, 0, 6,
 		Lt,
 		Halt,
 	}
@@ -333,8 +351,8 @@ func TestVM_Exec_Lt(t *testing.T) {
 
 func TestVM_Exec_Gt(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 6,
-		PushI, 1, 0, 4,
+		PushInt, 1, 0, 6,
+		PushInt, 1, 0, 4,
 		Gt,
 		Halt,
 	}
@@ -356,8 +374,8 @@ func TestVM_Exec_Gt(t *testing.T) {
 
 func TestVM_Exec_Lte_islower(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 4,
-		PushI, 1, 0, 6,
+		PushInt, 1, 0, 4,
+		PushInt, 1, 0, 6,
 		LtEq,
 		Halt,
 	}
@@ -380,8 +398,8 @@ func TestVM_Exec_Lte_islower(t *testing.T) {
 
 func TestVM_Exec_Lte_isequals(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 6,
-		PushI, 1, 0, 6,
+		PushInt, 1, 0, 6,
+		PushInt, 1, 0, 6,
 		LtEq,
 		Halt,
 	}
@@ -403,8 +421,8 @@ func TestVM_Exec_Lte_isequals(t *testing.T) {
 
 func TestVM_Exec_Gte_isGreater(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 6,
-		PushI, 1, 0, 4,
+		PushInt, 1, 0, 6,
+		PushInt, 1, 0, 4,
 		GtEq,
 		Halt,
 	}
@@ -426,8 +444,8 @@ func TestVM_Exec_Gte_isGreater(t *testing.T) {
 
 func TestVM_Exec_Gte_isEqual(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 6,
-		PushI, 1, 0, 6,
+		PushInt, 1, 0, 6,
+		PushInt, 1, 0, 6,
 		GtEq,
 		Halt,
 	}
@@ -449,7 +467,7 @@ func TestVM_Exec_Gte_isEqual(t *testing.T) {
 
 func TestVM_Exec_Shiftl(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 1,
+		PushInt, 1, 0, 1,
 		ShiftL, 3,
 		Halt,
 	}
@@ -471,7 +489,7 @@ func TestVM_Exec_Shiftl(t *testing.T) {
 
 func TestVM_Exec_Shiftr(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 8,
+		PushInt, 1, 0, 8,
 		ShiftR, 3,
 		Halt,
 	}
@@ -493,13 +511,13 @@ func TestVM_Exec_Shiftr(t *testing.T) {
 
 func TestVM_Exec_Jmpif(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 3,
-		PushI, 1, 0, 4,
+		PushInt, 1, 0, 3,
+		PushInt, 1, 0, 4,
 		Add,
-		PushI, 1, 0, 20,
+		PushInt, 1, 0, 20,
 		Lt,
 		JmpTrue, 0, 21,
-		PushI, 0, 3,
+		PushInt, 0, 3,
 		NoOp,
 		NoOp,
 		NoOp,
@@ -518,11 +536,11 @@ func TestVM_Exec_Jmpif(t *testing.T) {
 
 func TestVM_Exec_Jmp(t *testing.T) {
 	code := []byte{
-		PushI, 0, 3,
+		PushInt, 0, 3,
 		Jmp, 0, 14,
-		PushI, 0, 4,
+		PushInt, 0, 4,
 		Add,
-		PushI, 0, 15,
+		PushInt, 0, 15,
 		Add,
 		Halt,
 	}
@@ -544,8 +562,8 @@ func TestVM_Exec_Jmp(t *testing.T) {
 
 func TestVM_Exec_Call(t *testing.T) {
 	code := []byte{
-		PushI, 0, 10,
-		PushI, 0, 8,
+		PushInt, 0, 10,
+		PushInt, 0, 8,
 		Call, 0, 13, 2,
 		Halt,
 		NoOp,
@@ -579,10 +597,10 @@ func TestVM_Exec_Call(t *testing.T) {
 
 func TestVM_Exec_Callif_true(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 10,
-		PushI, 1, 0, 8,
-		PushI, 1, 0, 10,
-		PushI, 1, 0, 10,
+		PushInt, 1, 0, 10,
+		PushInt, 1, 0, 8,
+		PushInt, 1, 0, 10,
+		PushInt, 1, 0, 10,
 		Eq,
 		CallTrue, 0, 24, 2,
 		Halt,
@@ -617,10 +635,10 @@ func TestVM_Exec_Callif_true(t *testing.T) {
 
 func TestVM_Exec_Callif_false(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 10,
-		PushI, 1, 0, 8,
-		PushI, 1, 0, 10,
-		PushI, 1, 0, 2,
+		PushInt, 1, 0, 10,
+		PushInt, 1, 0, 8,
+		PushInt, 1, 0, 10,
+		PushInt, 1, 0, 2,
 		Eq,
 		CallTrue, 0, 25, 2,
 		Halt,
@@ -655,7 +673,7 @@ func TestVM_Exec_Callif_false(t *testing.T) {
 
 func TestVM_Exec_TosSize(t *testing.T) {
 	code := []byte{
-		PushI, 2, 10, 4, 5,
+		PushInt, 2, 10, 4, 5,
 		Size,
 		Halt,
 	}
@@ -680,8 +698,8 @@ func TestVM_Exec_TosSize(t *testing.T) {
 
 func TestVM_Exec_CallExt(t *testing.T) {
 	code := []byte{
-		PushI, 0, 10,
-		PushI, 0, 8,
+		PushInt, 0, 10,
+		PushInt, 0, 8,
 		CallExt, 227, 237, 86, 189, 8, 109, 137, 88, 72, 58, 18, 115, 79, 160, 174, 127, 92, 139, 177, 96, 239, 144, 146, 198, 126, 130, 237, 155, 25, 228, 199, 178, 41, 24, 45, 14, 2,
 		Halt,
 	}
@@ -735,7 +753,7 @@ func TestVM_Exec_Sload(t *testing.T) {
 
 func TestVM_Exec_Sstore(t *testing.T) {
 	code := []byte{
-		PushI, 9, 72, 105, 32, 84, 104, 101, 114, 101, 33, 33,
+		PushInt, 9, 72, 105, 32, 84, 104, 101, 114, 101, 33, 33,
 		StoreSt, 0,
 		Halt,
 	}
@@ -902,7 +920,7 @@ func TestVM_Exec_Calldata(t *testing.T) {
 
 func TestVM_Exec_Sha3(t *testing.T) {
 	code := []byte{
-		PushI, 0, 3,
+		PushInt, 0, 3,
 		SHA3,
 		Halt,
 	}
@@ -921,11 +939,11 @@ func TestVM_Exec_Sha3(t *testing.T) {
 
 func TestVM_Exec_Roll(t *testing.T) {
 	code := []byte{
-		PushI, 0, 3,
-		PushI, 0, 4,
-		PushI, 0, 5,
-		PushI, 0, 6,
-		PushI, 0, 7,
+		PushInt, 0, 3,
+		PushInt, 0, 4,
+		PushInt, 0, 5,
+		PushInt, 0, 6,
+		PushInt, 0, 7,
 		Roll, 2,
 		Halt,
 	}
@@ -969,16 +987,16 @@ func TestVM_Exec_NewMap(t *testing.T) {
 
 func TestVM_Exec_MapHasKey_true(t *testing.T) {
 	code := []byte{
-		PushI, 0x00, 0x01, //The key for MAPGETVAL
+		PushInt, 0x00, 0x01, //The key for MAPGETVAL
 
-		PushI, 0x01, 0x48, 0x48,
-		PushI, 0x00, 0x01,
+		PushInt, 0x01, 0x48, 0x48,
+		PushInt, 0x00, 0x01,
 
-		PushI, 0x01, 0x69, 0x69,
-		PushI, 0x00, 0x02,
+		PushInt, 0x01, 0x69, 0x69,
+		PushInt, 0x00, 0x02,
 
-		PushI, 0x01, 0x48, 0x69,
-		PushI, 0x00, 0x03,
+		PushInt, 0x01, 0x48, 0x69,
+		PushInt, 0x00, 0x03,
 
 		NewMap,
 
@@ -1015,16 +1033,16 @@ func TestVM_Exec_MapHasKey_true(t *testing.T) {
 
 func TestVM_Exec_MapHasKey_false(t *testing.T) {
 	code := []byte{
-		PushI, 0x00, 0x06, //The key for MAPGETVAL
+		PushInt, 0x00, 0x06, //The key for MAPGETVAL
 
-		PushI, 0x01, 0x48, 0x48,
-		PushI, 0x00, 0x01,
+		PushInt, 0x01, 0x48, 0x48,
+		PushInt, 0x00, 0x01,
 
-		PushI, 0x01, 0x69, 0x69,
-		PushI, 0x00, 0x02,
+		PushInt, 0x01, 0x69, 0x69,
+		PushInt, 0x00, 0x02,
 
-		PushI, 0x01, 0x48, 0x69,
-		PushI, 0x00, 0x03,
+		PushInt, 0x01, 0x48, 0x69,
+		PushInt, 0x00, 0x03,
 
 		NewMap,
 
@@ -1061,8 +1079,8 @@ func TestVM_Exec_MapHasKey_false(t *testing.T) {
 
 func TestVM_Exec_MapPush(t *testing.T) {
 	code := []byte{
-		PushI, 1, 72, 105,
-		PushI, 0, 0x03,
+		PushInt, 1, 72, 105,
+		PushInt, 0, 0x03,
 		NewMap,
 		MapPush,
 		Halt,
@@ -1107,16 +1125,16 @@ func TestVM_Exec_MapPush(t *testing.T) {
 
 func TestVM_Exec_MapGetVAL(t *testing.T) {
 	code := []byte{
-		PushI, 0x00, 0x01, //The key for MAPGETVAL
+		PushInt, 0x00, 0x01, //The key for MAPGETVAL
 
-		PushI, 0x01, 0x48, 0x48,
-		PushI, 0x00, 0x01,
+		PushInt, 0x01, 0x48, 0x48,
+		PushInt, 0x00, 0x01,
 
-		PushI, 0x01, 0x69, 0x69,
-		PushI, 0x00, 0x02,
+		PushInt, 0x01, 0x69, 0x69,
+		PushInt, 0x00, 0x02,
 
-		PushI, 0x01, 0x48, 0x69,
-		PushI, 0x00, 0x03,
+		PushInt, 0x01, 0x48, 0x69,
+		PushInt, 0x00, 0x03,
 
 		NewMap,
 
@@ -1153,14 +1171,14 @@ func TestVM_Exec_MapGetVAL(t *testing.T) {
 
 func TestVM_Exec_MapSetVal(t *testing.T) {
 	code := []byte{
-		PushI, 0x01, 0x55, 0x55, //Value to be reset by MAPSETVAL
-		PushI, 0x00, 0x03,
+		PushInt, 0x01, 0x55, 0x55, //Value to be reset by MAPSETVAL
+		PushInt, 0x00, 0x03,
 
-		PushI, 0x01, 0x48, 0x69,
-		PushI, 0x00, 0x03,
+		PushInt, 0x01, 0x48, 0x69,
+		PushInt, 0x00, 0x03,
 
-		PushI, 0x01, 0x69, 0x69,
-		PushI, 0x00, 0x02,
+		PushInt, 0x01, 0x69, 0x69,
+		PushInt, 0x00, 0x02,
 
 		NewMap,
 
@@ -1207,16 +1225,16 @@ func TestVM_Exec_MapSetVal(t *testing.T) {
 
 func TestVM_Exec_MapRemove(t *testing.T) {
 	code := []byte{
-		PushI, 0x00, 0x03, // The Key to be removed with MAPREMOVE
+		PushInt, 0x00, 0x03, // The Key to be removed with MAPREMOVE
 
-		PushI, 0x01, 0x48, 0x69,
-		PushI, 0x00, 0x03,
+		PushInt, 0x01, 0x48, 0x69,
+		PushInt, 0x00, 0x03,
 
-		PushI, 0x01, 0x48, 0x48,
-		PushI, 0x00, 0x01,
+		PushInt, 0x01, 0x48, 0x48,
+		PushInt, 0x00, 0x01,
 
-		PushI, 0x01, 0x69, 0x69,
-		PushI, 0x00, 0x02,
+		PushInt, 0x01, 0x69, 0x69,
+		PushInt, 0x00, 0x02,
 
 		NewMap,
 
@@ -1291,7 +1309,7 @@ func TestVM_Exec_NewArr(t *testing.T) {
 
 func TestVM_Exec_ArrAppend(t *testing.T) {
 	code := []byte{
-		PushI, 0x01, 0xFF, 0x00,
+		PushInt, 0x01, 0xFF, 0x00,
 		NewArr,
 		ArrAppend,
 		Halt,
@@ -1320,12 +1338,12 @@ func TestVM_Exec_ArrAppend(t *testing.T) {
 
 func TestVM_Exec_ArrInsert(t *testing.T) {
 	code := []byte{
-		PushI, 0x01, 0x00, 0x00,
-		PushI, 0x01, 0x00, 0x00,
+		PushInt, 0x01, 0x00, 0x00,
+		PushInt, 0x01, 0x00, 0x00,
 
-		PushI, 0x01, 0xFF, 0x00,
+		PushInt, 0x01, 0xFF, 0x00,
 
-		PushI, 0x01, 0xFF, 0x00,
+		PushInt, 0x01, 0xFF, 0x00,
 		NewArr,
 		ArrAppend,
 		ArrAppend,
@@ -1361,10 +1379,10 @@ func TestVM_Exec_ArrInsert(t *testing.T) {
 
 func TestVM_Exec_ArrRemove(t *testing.T) {
 	code := []byte{
-		PushI, 0x01, 0x01, 0x00, //Index of element to remove
-		PushI, 0x01, 0xBB, 0x00,
-		PushI, 0x01, 0xAA, 0x00,
-		PushI, 0x01, 0xFF, 0x00,
+		PushInt, 0x01, 0x01, 0x00, //Index of element to remove
+		PushInt, 0x01, 0xBB, 0x00,
+		PushInt, 0x01, 0xAA, 0x00,
+		PushInt, 0x01, 0xFF, 0x00,
 
 		NewArr,
 
@@ -1418,10 +1436,10 @@ func TestVM_Exec_ArrRemove(t *testing.T) {
 
 func TestVM_Exec_ArrAt(t *testing.T) {
 	code := []byte{
-		PushI, 0x01, 0x02, 0x00, // index for ARRAT
-		PushI, 0x01, 0xBB, 0x00,
-		PushI, 0x01, 0xAA, 0x00,
-		PushI, 0x01, 0xFF, 0x00,
+		PushInt, 0x01, 0x02, 0x00, // index for ARRAT
+		PushInt, 0x01, 0xBB, 0x00,
+		PushInt, 0x01, 0xAA, 0x00,
+		PushInt, 0x01, 0xFF, 0x00,
 
 		NewArr,
 
@@ -1478,7 +1496,7 @@ func TestVM_Exec_NonValidOpCode(t *testing.T) {
 
 func TestVM_Exec_ArgumentsExceedInstructionSet(t *testing.T) {
 	code := []byte{
-		PushI, 0x00, 0x00, PushI, 0x0b, 0x01, 0x00, 0x03, 0x12, 0x05,
+		PushInt, 0x00, 0x00, PushInt, 0x0b, 0x01, 0x00, 0x03, 0x12, 0x05,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1488,7 +1506,7 @@ func TestVM_Exec_ArgumentsExceedInstructionSet(t *testing.T) {
 
 	tos, _ := vm.evaluationStack.Pop()
 
-	expected := "push: Instruction set out of bounds"
+	expected := "pushint: Instruction set out of bounds"
 	actual := string(tos)
 	if actual != expected {
 		t.Errorf("Expected error message to be '%v' but was '%v'", expected, actual)
@@ -1497,7 +1515,7 @@ func TestVM_Exec_ArgumentsExceedInstructionSet(t *testing.T) {
 
 func TestVM_Exec_PopOnEmptyStack(t *testing.T) {
 	code := []byte{
-		PushI, 0x00, 0x01,
+		PushInt, 0x00, 0x01,
 		SHA3,
 		Sub, 0x02, 0x03,
 	}
@@ -1519,7 +1537,7 @@ func TestVM_Exec_PopOnEmptyStack(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_InstructionSetOutOfBounds(t *testing.T) {
 	code := []byte{
-		PushI, 0, 20,
+		PushInt, 0, 20,
 		Roll, 0,
 	}
 
@@ -1578,7 +1596,7 @@ func TestVM_Exec_FuzzReproduction_IndexOutOfBounds1(t *testing.T) {
 
 func TestVM_Exec_FuzzReproduction_IndexOutOfBounds2(t *testing.T) {
 	code := []byte{
-		PushI, 4, 46, 110, 66, 50, 255, StoreSt, 123, 119,
+		PushInt, 4, 46, 110, 66, 50, 255, StoreSt, 123, 119,
 	}
 
 	vm := NewTestVM([]byte{})
@@ -1601,11 +1619,11 @@ func TestVM_Exec_FunctionCallSub(t *testing.T) {
 		// start ABI
 		CallData,
 		Dup,
-		PushI, 1, 0, 1,
+		PushInt, 1, 0, 1,
 		Eq,
 		JmpTrue, 0, 20,
 		Dup,
-		PushI, 1, 0, 2,
+		PushInt, 1, 0, 2,
 		Eq,
 		JmpTrue, 0, 23,
 		Halt,
@@ -1644,11 +1662,11 @@ func TestVM_Exec_FunctionCall(t *testing.T) {
 		// start ABI
 		CallData,
 		Dup,
-		PushI, 1, 0, 1,
+		PushInt, 1, 0, 1,
 		Eq,
 		JmpTrue, 0, 20,
 		Dup,
-		PushI, 1, 0, 2,
+		PushInt, 1, 0, 2,
 		Eq,
 		JmpTrue, 0, 23,
 		Halt,
@@ -1762,8 +1780,8 @@ func TestVM_Exec_FuzzReproduction_EdgecaseLastOpcodePlusOne(t *testing.T) {
 
 func TestVM_PopBytes(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 8,
-		PushI, 1, 0, 8,
+		PushInt, 1, 0, 8,
+		PushInt, 1, 0, 8,
 		Add,
 		Halt,
 	}
@@ -1819,10 +1837,10 @@ func TestVM_FuzzTest_Reproduction_IndexOutOfRange(t *testing.T) {
 
 func TestVM_GasCalculation(t *testing.T) {
 	code := []byte{
-		PushI, 64, 0, 8, 179, 91, 9, 9, 6, 136, 231, 56, 7, 146, 99, 170, 98, 183, 40, 118, 185, 95,
+		PushInt, 64, 0, 8, 179, 91, 9, 9, 6, 136, 231, 56, 7, 146, 99, 170, 98, 183, 40, 118, 185, 95,
 		106, 14, 143, 25, 99, 79, 76, 222, 197, 5, 218, 90, 216, 47, 218, 74, 53, 139, 62, 28, 104,
 		180, 139, 65, 103, 193, 244, 169, 85, 39, 160, 218, 158, 207, 118, 37, 78, 42, 186, 64, 4, 70, 70, 190, 177,
-		PushI, 1, 0, 8,
+		PushInt, 1, 0, 8,
 		Add,
 		Halt,
 	}
@@ -1844,8 +1862,8 @@ func TestVM_GasCalculation(t *testing.T) {
 
 func TestVM_PopBytesOutOfGas(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 8,
-		PushI, 1, 0, 8,
+		PushInt, 1, 0, 8,
+		PushInt, 1, 0, 8,
 		Add,
 		Halt,
 	}
@@ -1969,23 +1987,23 @@ func modularExpContract(base big.Int, exponent big.Int, modulus big.Int) []byte 
 	addressForLoop := UInt16ToByteArray(uint16(20) + uint16(len(baseVal)) + uint16(len(modulusVal)) + uint16(len(exponentVal)))
 
 	contract := []byte{
-		PushI,
+		PushInt,
 	}
 	contract = append(contract, baseVal...)
-	contract = append(contract, PushI)
+	contract = append(contract, PushInt)
 	contract = append(contract, modulusVal...)
 	contract = append(contract, []byte{
 		Dup,
-		PushI, 1, 0, 0,
+		PushInt, 1, 0, 0,
 		Eq,
 		JmpTrue,
 	}...)
 	contract = append(contract, addressBeforeExp[1])
 	contract = append(contract, addressBeforeExp[0])
 	contract = append(contract, []byte{
-		PushI, 1, 0, 1, // Counter (c)
-		PushI, 1, 0, 0, //i
-		PushI,
+		PushInt, 1, 0, 1, // Counter (c)
+		PushInt, 1, 0, 0, //i
+		PushInt,
 	}...)
 	contract = append(contract, exponentVal...)
 	contract = append(contract, []byte{
@@ -2016,7 +2034,7 @@ func modularExpContract(base big.Int, exponent big.Int, modulus big.Int) []byte 
 		// Order: exp, i - counter, modulus, base,
 		Dup,
 		Roll, 1,
-		PushI, 1, 0, 1,
+		PushInt, 1, 0, 1,
 		Add,
 		Dup,
 		Roll, 1,
@@ -2045,13 +2063,13 @@ func modularExpContract(base big.Int, exponent big.Int, modulus big.Int) []byte 
 
 func TestVm_Exec_Loop(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 0, //i
-		PushI, 1, 0, 13, // Exp
+		PushInt, 1, 0, 0, //i
+		PushInt, 1, 0, 13, // Exp
 
 		// Order: exp, i
 		Dup,
 		Roll, 1,
-		PushI, 1, 0, 1,
+		PushInt, 1, 0, 1,
 		Add,
 		Dup,
 		Roll, 1,
@@ -2079,17 +2097,17 @@ func TestVm_Exec_Loop(t *testing.T) {
 
 func TestVm_Exec_ModularExponentiation_ContractImplementation(t *testing.T) {
 	code := []byte{
-		PushI, 1, 0, 4, // Base
-		PushI, 2, 0, 1, 241, // Modulus
+		PushInt, 1, 0, 4, // Base
+		PushInt, 2, 0, 1, 241, // Modulus
 		// IF modulus equals 0
 		Dup,
-		PushI, 1, 0, 0,
+		PushInt, 1, 0, 0,
 		Eq,
 		JmpTrue, 0, 46, // Adjust address
 
-		PushI, 1, 0, 1, // Counter (c)
-		PushI, 1, 0, 0, //i
-		PushI, 1, 0, 13, // Exp
+		PushInt, 1, 0, 1, // Counter (c)
+		PushInt, 1, 0, 0, //i
+		PushInt, 1, 0, 13, // Exp
 
 		//LOOP start
 		//Duplicate arguments
@@ -2113,7 +2131,7 @@ func TestVm_Exec_ModularExponentiation_ContractImplementation(t *testing.T) {
 		// Order: exp, i - counter, modulus, base,
 		Dup,
 		Roll, 1,
-		PushI, 1, 0, 1,
+		PushInt, 1, 0, 1,
 		Add,
 		Dup,
 		Roll, 1,
@@ -2146,5 +2164,25 @@ func TestVm_Exec_ModularExponentiation_ContractImplementation(t *testing.T) {
 
 	if ByteArrayToInt(actual[1:]) != expected {
 		t.Errorf("Expected actual result to be '%v' but was '%v'", expected, actual)
+	}
+}
+
+// Helper functions
+// ----------------
+
+func execCode(code []byte) (VM, bool) {
+	vm := NewTestVM([]byte{})
+	mc := NewMockContext(code)
+	vm.context = mc
+	isSuccess := vm.Exec(false)
+
+	return vm, isSuccess
+}
+
+func assertBytes(t *testing.T, actual []byte, expected ...byte) {
+	assert.Equal(t, len(actual), len(expected))
+
+	for i, b := range actual {
+		assert.Equal(t, b, expected[i])
 	}
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -129,6 +129,45 @@ func TestVM_Exec_PushChar_Invalid(t *testing.T) {
 	assert.Equal(t, string(tos), "pushchar: invalid ASCII code 128")
 }
 
+func TestVM_Exec_PushStr_Empty(t *testing.T) {
+	code := []byte{
+		PushStr, 0, // ""
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assertBytes(t, tos)
+}
+
+func TestVM_Exec_PushStr(t *testing.T) {
+	code := []byte{
+		PushStr, 5, 104, 101, 108, 108, 111, // "hello"
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assert.Equal(t, string(tos), "hello")
+}
+
+func TestVM_Exec_PushStr_Invalid(t *testing.T) {
+	code := []byte{
+		PushStr, 5, 104, 101, 200, 108, 111, // "hello"
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, !isSuccess)
+
+	tos, _ := vm.evaluationStack.Pop()
+	assert.Equal(t, string(tos), "pushstr: invalid ASCII code 200")
+}
+
 func TestVM_Exec_Addition(t *testing.T) {
 	code := []byte{
 		PushInt, 1, 0, 125,


### PR DESCRIPTION
Support
- PushInt
- PushBool
- PushChar
- PushStr
- Push (generic)

fixes Issue https://github.com/bazo-blockchain/bazo-vm/issues/5