### PR TITLE
Swap opcode

### DIFF
--- a/vm/op_codes.go
+++ b/vm/op_codes.go
@@ -9,6 +9,7 @@ const (
 	Push
 	Dup
 	Roll
+	Swap
 	Pop
 	Add
 	Sub
@@ -91,6 +92,7 @@ var OpCodes = []OpCode{
 	{Push, "push", 1, []int{BYTES}, 1, 1},
 	{Dup, "dup", 0, nil, 1, 2},
 	{Roll, "roll", 1, []int{BYTE}, 1, 2},
+	{Swap, "swap", 0, nil, 1, 2},
 	{Pop, "pop", 0, nil, 1, 1},
 	{Add, "add", 0, nil, 1, 2},
 	{Sub, "sub", 0, nil, 1, 2},

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -304,6 +304,18 @@ func (vm *VM) Exec(trace bool) bool {
 					return false
 				}
 			}
+		case Swap:
+			last, err1 := vm.evaluationStack.Pop()
+			secondLast, err2 := vm.evaluationStack.Pop()
+			if !vm.checkErrors(opCode.Name, err1, err2) {
+				return false
+			}
+
+			err1 = vm.evaluationStack.Push(last)
+			err2 = vm.evaluationStack.Push(secondLast)
+			if !vm.checkErrors(opCode.Name, err1, err2) {
+				return false
+			}
 		case Pop:
 			_, rerr := vm.PopBytes(opCode)
 			if !vm.checkErrors(opCode.Name, rerr) {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1454,6 +1454,42 @@ func TestVM_Exec_Roll(t *testing.T) {
 	}
 }
 
+func TestVM_Exec_Swap(t *testing.T) {
+	code := []byte{
+		Push, 1, 1,
+		Push, 1, 2,
+		Push, 1, 3,
+		Swap,
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, isSuccess)
+
+	last, err := vm.evaluationStack.Pop()
+	assert.NilError(t, err)
+	secondLast, err := vm.evaluationStack.Pop()
+	assert.NilError(t, err)
+
+	assertBytes(t, last, 2)
+	assertBytes(t, secondLast, 3)
+}
+
+func TestVM_Exec_SwapError(t *testing.T) {
+	code := []byte{
+		Push, 1, 1,
+		Swap,
+		Halt,
+	}
+
+	vm, isSuccess := execCode(code)
+	assert.Assert(t, !isSuccess)
+
+	errMsg, err := vm.evaluationStack.Pop()
+	assert.NilError(t, err)
+	assert.Equal(t, string(errMsg), "swap: pop() on empty stack")
+}
+
 func TestVM_Exec_NewMap(t *testing.T) {
 	code := []byte{
 		NewMap,


### PR DESCRIPTION
Resolves https://github.com/bazo-blockchain/bazo-vm/issues/34.
Swap opcode is required for multiple struct field assignment with a function call.

```cs
                struct Person {
	 		int balance
			bool isValid
		}

		function (int, bool) test() {
			Person p = new Person()
			p.balance, p.isValid = test2()
			
			return p.balance, p.isValid
		}

		function (int, bool) test2() {
			return 100, true
		}
```
See Lazo https://github.com/bazo-blockchain/lazo/pull/63 for usage.

