### PR TITLE
Fix map to override keys

### DIFF
--- a/vm/op_codes.go
+++ b/vm/op_codes.go
@@ -47,7 +47,6 @@ const (
 	CallData // Parameters and function signature hash
 	NewMap
 	MapHasKey
-	MapPush
 	MapGetVal
 	MapSetVal
 	MapRemove
@@ -131,7 +130,6 @@ var OpCodes = []OpCode{
 	{CallData, "calldata", 0, nil, 1, 1},
 	{NewMap, "newmap", 0, nil, 1, 2},
 	{MapHasKey, "maphaskey", 0, nil, 1, 2},
-	{MapPush, "mappush", 0, nil, 1, 2},
 	{MapGetVal, "mapgetval", 0, nil, 1, 2},
 	{MapSetVal, "mapsetval", 0, nil, 1, 2},
 	{MapRemove, "mapremove", 0, nil, 1, 2},

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1590,9 +1590,9 @@ func TestVM_Exec_MapHasKey_true(t *testing.T) {
 
 		NewMap,
 
-		MapPush,
-		MapPush,
-		MapPush,
+		MapSetVal,
+		MapSetVal,
+		MapSetVal,
 
 		MapHasKey,
 
@@ -1636,9 +1636,9 @@ func TestVM_Exec_MapHasKey_false(t *testing.T) {
 
 		NewMap,
 
-		MapPush,
-		MapPush,
-		MapPush,
+		MapSetVal,
+		MapSetVal,
+		MapSetVal,
 
 		MapHasKey,
 
@@ -1667,12 +1667,12 @@ func TestVM_Exec_MapHasKey_false(t *testing.T) {
 	}
 }
 
-func TestVM_Exec_MapPush(t *testing.T) {
+func TestVM_Exec_MapSetVal(t *testing.T) {
 	code := []byte{
 		PushInt, 1, 72, 105,
 		Push, 1, 0x03,
 		NewMap,
-		MapPush,
+		MapSetVal,
 		Halt,
 	}
 
@@ -1728,9 +1728,9 @@ func TestVM_Exec_MapGetVAL(t *testing.T) {
 
 		NewMap,
 
-		MapPush,
-		MapPush,
-		MapPush,
+		MapSetVal,
+		MapSetVal,
+		MapSetVal,
 
 		MapGetVal,
 
@@ -1759,7 +1759,7 @@ func TestVM_Exec_MapGetVAL(t *testing.T) {
 	}
 }
 
-func TestVM_Exec_MapSetVal(t *testing.T) {
+func TestVM_Exec_MapSetVal_Multiple(t *testing.T) {
 	code := []byte{
 		Push, 2, 0x55, 0x55, //Value to be reset by MAPSETVAL
 		Push, 1, 0x03,
@@ -1772,9 +1772,8 @@ func TestVM_Exec_MapSetVal(t *testing.T) {
 
 		NewMap,
 
-		MapPush,
-		MapPush,
-
+		MapSetVal,
+		MapSetVal,
 		MapSetVal,
 
 		Halt,
@@ -1828,9 +1827,9 @@ func TestVM_Exec_MapRemove(t *testing.T) {
 
 		NewMap,
 
-		MapPush,
-		MapPush,
-		MapPush,
+		MapSetVal,
+		MapSetVal,
+		MapSetVal,
 
 		MapRemove,
 		Halt,


### PR DESCRIPTION
Remove redundant MapPush: VM should not allow users to append new keys to the end.
Fix MapSetVal: VM should replace existing key. If not present, it should append it.

Resolves https://github.com/bazo-blockchain/bazo-vm/issues/45